### PR TITLE
tar/import: use new writing APIs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Hack in updated ostree
+      run: rpm -Uvh https://kojipkgs.fedoraproject.org//packages/ostree/2021.2/2.fc33/x86_64/ostree-{,devel-,libs-}2021.2-2.fc33.x86_64.rpm
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,3 @@ lto = "thin"
 
 [patch.crates-io]
 oci-distribution = { git = 'https://github.com/cgwalters/krustlet', branch = 'streaming-client' }
-ostree = { git = 'https://gitlab.com/fkrull/ostree-rs', rev = 'fd2b57864938e9b3c0fc0c4496da29a099ad4616' }
-ostree-sys = { git = 'https://gitlab.com/fkrull/ostree-rs', rev = 'fd2b57864938e9b3c0fc0c4496da29a099ad4616' }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1.0"
 ostree-ext = { path = "../lib", features = ["container"] }
 clap = "2.33.3"
 structopt = "0.3.21"
-ostree = { version = "0.10.0", features = ["v2021_1"] }
+ostree = { version = "0.11.0", features = ["v2021_2"] }
 libc = "0.2.92"
 tokio = { version = "1", features = ["full"] }
 gio = "0.9.1"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -36,7 +36,7 @@ libc = "0.2.92"
 openat = "0.1.20"
 openat-ext = "0.2.0"
 openssl = "0.10.33"
-ostree = { version = "0.10.0", features = ["v2021_1" ]}
+ostree = { version = "0.11.0", features = ["v2021_2" ]}
 os_pipe = "0.9.2"
 ostree-sys = "0.7.2"
 tar = "0.4.33"

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -70,7 +70,7 @@ fn generate_test_tarball(dir: &Utf8Path) -> Result<Utf8PathBuf> {
 fn test_tar_import_export() -> Result<()> {
     let cancellable = gio::NONE_CANCELLABLE;
 
-    let tempdir = tempfile::tempdir()?;
+    let tempdir = tempfile::tempdir_in("/var/tmp")?;
     let path = Utf8Path::from_path(tempdir.path()).unwrap();
     let srcdir = &path.join("src");
     std::fs::create_dir(srcdir)?;
@@ -80,7 +80,7 @@ fn test_tar_import_export() -> Result<()> {
     std::fs::create_dir(destdir)?;
     let destrepodir = &destdir.join("repo");
     let destrepo = ostree::Repo::new_for_path(destrepodir);
-    destrepo.create(ostree::RepoMode::Archive, cancellable)?;
+    destrepo.create(ostree::RepoMode::BareUser, cancellable)?;
 
     let imported_commit: String = ostree_ext::tar::import_tar(&destrepo, src_tar)?;
     let (commitdata, _) = destrepo.load_commit(&imported_commit)?;


### PR DESCRIPTION
This is a lot more efficient; before we were creating a thread
per object, etc.