### PR TITLE
WIP: Use skopeo to fetch images

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,3 @@ members = ["cli", "lib"]
 [profile.release]
 codegen-units = 1
 lto = "thin"
-
-[patch.crates-io]
-oci-distribution = { git = 'https://github.com/cgwalters/krustlet', branch = 'streaming-client' }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0"
-ostree-ext = { path = "../lib", features = ["container"] }
+ostree-ext = { path = "../lib" }
 clap = "2.33.3"
 structopt = "0.3.21"
 ostree = { version = "0.11.0", features = ["v2021_2"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,30 +1,16 @@
 [package]
 authors = ["Colin Walters <walters@verbum.org>"]
+description = "Extension APIs for OSTree"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-ext"
 version = "0.1.0"
-description = "Extension APIs for OSTree"
-
-
-[features]
-# Enable the container API
-container = [
-    "cjson",
-    "flate2",
-    "futures",
-    "phf",
-    "nix",
-    "oci-distribution",
-    "tokio",
-    "serde",
-    "serde_json",
-]
 
 [dependencies]
 anyhow = "1.0"
+bytes = "1.0.1"
 camino = "1.0.4"
 fn-error-context = "0.1.1"
 gio = "0.9.1"
@@ -33,28 +19,59 @@ glib-sys = "0.10.1"
 gvariant = "0.4.0"
 hex = "0.4.3"
 libc = "0.2.92"
+oci-distribution = "0.6.0"
 openat = "0.1.20"
 openat-ext = "0.2.0"
 openssl = "0.10.33"
-ostree = { version = "0.11.0", features = ["v2021_2" ]}
 os_pipe = "0.9.2"
+tokio-fd = "0.3.0"
 ostree-sys = "0.7.2"
 tar = "0.4.33"
+tempfile = "3.2.0"
+tokio-stream = "0.1.5"
+async-compression = { version = "0.3.7", features = ["tokio", "zstd", "gzip" ] }
 
-#ostree-container deps
-cjson = { version = "0.1.1", optional = true }
-flate2 = {version = "1.0.20", optional = true }
-futures = { version = "0.3.13", optional = true }
-phf = { version = "0.8.0", features = ["macros"], optional = true }
-nix = { version = "0.20.0", optional = true }
-oci-distribution = { version = "0.6.0", optional = true }
-tokio = { version = "1", features = ["full"], optional = true }
-serde = { version = "1.0.125", optional = true }
-serde_json = { version = "1.0.64", optional = true }
+[dependencies.cjson]
+version = "0.1.1"
+
+[dependencies.flate2]
+version = "1.0.20"
+
+[dependencies.futures]
+version = "0.3.13"
+
+[dependencies.hyper]
+features = ["full"]
+version = "0.14"
+
+[dependencies.nix]
+version = "0.20.0"
+
+[dependencies.ostree]
+features = ["v2021_2"]
+version = "0.11.0"
+
+[dependencies.phf]
+features = ["macros"]
+version = "0.8.0"
+
+[dependencies.serde]
+features = ["derive"]
+version = "1.0.125"
+
+[dependencies.serde_json]
+version = "1.0.64"
+
+[dependencies.tokio]
+features = ["full"]
+version = "1"
+
+[dependencies.tokio-util]
+features = ["io"]
+version = "0.6"
 
 [dev-dependencies]
 clap = "2.33.3"
 indoc = "1.0.3"
 sh-inline = "0.1.0"
-tempfile = "3.2.0"
 structopt = "0.3.21"

--- a/lib/src/container/asynctar.rs
+++ b/lib/src/container/asynctar.rs
@@ -1,0 +1,115 @@
+use anyhow::Result;
+use futures::{Future, FutureExt, Stream, StreamExt};
+use std::io::prelude::*;
+use tokio::io::AsyncRead;
+
+pub(crate) struct TarEntry {
+    pub(crate) header: tar::Header,
+    pub(crate) content: Option<tokio::sync::mpsc::Receiver<bytes::Bytes>>,
+}
+
+#[must_use]
+pub(crate) fn parse_tar<S: AsyncRead + Unpin + Send + 'static>(
+    s: S,
+) -> Result<(
+    impl Stream<Item = Result<TarEntry>>,
+    impl Future<Output = Result<()>>,
+)> {
+    let (tx_tar, rx_tar) = tokio::sync::mpsc::channel(2);
+    let (pipein, mut pipeout) = os_pipe::pipe()?;
+
+    // Bridge from the async input to a synchronous pipe
+    let copier = tokio::spawn(async move {
+        let mut input = tokio_util::io::ReaderStream::new(s).boxed();
+        while let Some(buf) = input.next().await {
+            let buf = buf?;
+            // TODO blocking executor
+            pipeout.write_all(&buf)?;
+        }
+        Ok::<_, anyhow::Error>(())
+    })
+    .map(|e| e.unwrap())
+    .boxed_local();
+
+    // Thread which reads from the pipe (synchronously) and parses the tar archive
+    let processor = tokio::task::spawn_blocking(move || {
+        let mut archive = tar::Archive::new(pipein);
+        let mut buf = vec![0u8; 4096];
+        for entry in archive.entries()? {
+            let mut entry = entry?;
+            let (tx_content, rx_content) = if entry.header().entry_type() == tar::EntryType::Regular
+            {
+                let (s, r) = tokio::sync::mpsc::channel::<bytes::Bytes>(1);
+                (Some(s), Some(r))
+            } else {
+                (None, None)
+            };
+            if tx_tar
+                .blocking_send(Ok::<_, anyhow::Error>(TarEntry {
+                    header: entry.header().clone(),
+                    content: rx_content,
+                }))
+                .is_err()
+            {
+                // If the receiver closes the channel, we're done
+                break;
+            };
+            if let Some(tx_content) = tx_content {
+                loop {
+                    let n = entry.read(&mut buf[..])?;
+                    if 0 == n {
+                        break;
+                    } else {
+                        if tx_content
+                            .blocking_send(bytes::Bytes::copy_from_slice(&buf[0..n]))
+                            .is_err()
+                        {
+                            // Receiver closing means they aren't interested in the content
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        Ok::<_, anyhow::Error>(())
+    })
+    .boxed_local();
+
+    let worker = async move {
+        let (a, b) = tokio::join!(copier, processor);
+        a?;
+        b??;
+        Ok::<_, anyhow::Error>(())
+    }
+    .boxed_local();
+
+    Ok((tokio_stream::wrappers::ReceiverStream::new(rx_tar), worker))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream::TryStreamExt;
+
+    const EXAMPLEOS_TAR: &[u8] = include_bytes!("tests/it/fixtures/exampleos.tar.zst");
+
+    #[tokio::test]
+    async fn test_import() -> Result<()> {
+        let uncomp = async_compression::tokio::bufread::ZstdDecoder::new(EXAMPLEOS_TAR);
+        let (s, worker) = parse_tar(uncomp)?;
+        let n = s
+            .try_fold(0usize, |acc, f| async move {
+                let n = if let Some(s) = f.content.map(tokio_stream::wrappers::ReceiverStream::new)
+                {
+                    s.fold(acc, |acc, buf| async move { acc + buf.len() }).await
+                } else {
+                    acc
+                };
+                Ok::<_, anyhow::Error>(n)
+            })
+            .await?;
+        worker.await?;
+        assert_eq!(n, 35usize);
+        Ok(())
+    }
+}

--- a/lib/src/container/client.rs
+++ b/lib/src/container/client.rs
@@ -1,11 +1,118 @@
 //! APIs for extracting OSTree commits from container images
 
-use std::io::Write;
-
+use super::oci;
 use super::Result;
 use anyhow::{anyhow, Context};
 use fn_error_context::context;
-use oci_distribution::manifest::OciDescriptor;
+use futures::{Future, FutureExt, StreamExt, TryFutureExt, TryStreamExt};
+use std::convert::TryFrom;
+use std::convert::TryInto;
+use std::io::prelude::*;
+use std::os::unix::io::{AsRawFd, IntoRawFd};
+use std::process::Stdio;
+use std::rc::Rc;
+use tokio::{io::AsyncRead, process::Command};
+
+fn new_skopeo() -> tokio::process::Command {
+    let mut cmd = Command::new("skopeo");
+    cmd.kill_on_drop(true);
+    cmd
+}
+
+fn skopeo_spawn(mut cmd: Command) -> Result<tokio::process::Child> {
+    let cmd = cmd.stdin(Stdio::null()).stderr(Stdio::piped());
+    Ok(cmd.spawn().context("Failed to exec skopeo")?)
+}
+
+fn skopeo_ref(imgref: &oci_distribution::Reference) -> String {
+    format!("docker://{}", imgref)
+}
+
+#[context("Fetching manifest")]
+async fn fetch_manifest(imgref: &oci_distribution::Reference) -> Result<(oci::Manifest, String)> {
+    let mut proc = new_skopeo();
+    proc.args(&["inspect", "--raw"]).arg(skopeo_ref(imgref));
+    proc.stdout(Stdio::piped());
+    let proc = skopeo_spawn(proc)?.wait_with_output().await?;
+    if !proc.status.success() {
+        let errbuf = String::from_utf8_lossy(&proc.stderr);
+        return Err(anyhow!("skopeo inspect failed\n{}", errbuf));
+    }
+    let raw_manifest = proc.stdout;
+    let digest = openssl::hash::hash(openssl::hash::MessageDigest::sha256(), &raw_manifest)?;
+    let digest = format!("sha256:{}", hex::encode(&digest));
+    Ok((serde_json::from_slice(&raw_manifest)?, digest))
+}
+
+#[allow(unsafe_code)]
+/// Given a file descriptor backed object, set up the child process to use
+/// it o
+fn tokio_command_take_fd<F>(cmd: &mut Command, fd: F, target: libc::c_int)
+where
+    F: AsRawFd + Send + Sync + 'static,
+{
+    unsafe {
+        cmd.pre_exec(move || {
+            nix::unistd::dup2(fd.as_raw_fd(), target)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
+                .map(|_| {})
+        });
+    }
+}
+
+/// Fetch the whole content of a container image into OCI Archive format, which is
+/// just a tarball of the manifest and layers, streaming the result.
+async fn fetch_oci_archive(
+    imgref: &oci_distribution::Reference,
+) -> Result<(impl AsyncRead, impl Future<Output = Result<()>>)> {
+    let mut proc = new_skopeo();
+    proc.stdout(Stdio::null());
+    let target_fd = 5i32;
+    let (pipein, pipeout) = os_pipe::pipe()?;
+    // TODO add api to tokio to pass file descriptors
+    proc.arg("copy")
+        .arg(skopeo_ref(imgref))
+        .arg(format!("oci-archive:///proc/self/fd/{}", target_fd));
+    tokio_command_take_fd(&mut proc, pipeout, target_fd);
+    let proc = proc.status().err_into().and_then(|e| async move {
+        if !e.success() {
+            return Err(anyhow!("skopeo failed: {}", e));
+        }
+        Ok(())
+    });
+    // FIXME this leaks the pipefd on error
+    let pipein = tokio_fd::AsyncFd::try_from(pipein.into_raw_fd())?;
+    Ok((pipein, proc))
+}
+
+fn read_oci_archive_blob(
+    archive: impl AsyncRead + Send + Unpin + 'static,
+    blobid: &str,
+) -> Result<(
+    impl Future<Output = Result<super::asynctar::TarEntry>>,
+    impl Future<Output = Result<()>>,
+)> {
+    let blobpath = Rc::new(format!("blobs/sha256/{}", blobid));
+    let (s, worker) = super::asynctar::parse_tar(archive)?;
+    let blobpath_copy = Rc::clone(&blobpath);
+    let blob = s
+        .try_filter_map(move |elt| {
+            let blobpath = Rc::clone(&blobpath_copy);
+            async move {
+                if elt.header.path()?.to_str() == Some(blobpath.as_str()) {
+                    Ok(Some(elt))
+                } else {
+                    Ok(None)
+                }
+            }
+        })
+        .boxed_local()
+        .into_future()
+        .then(|(first, _)| async move {
+            first.ok_or_else(|| anyhow!("Couldn't find entry"))?
+        });
+    Ok((blob.boxed_local(), worker))
+}
 
 /// The result of an import operation
 #[derive(Debug)]
@@ -16,58 +123,54 @@ pub struct Import {
     pub image_digest: String,
 }
 
-#[context("Fetching layer descriptor")]
-async fn fetch_layer_descriptor(
-    client: &mut oci_distribution::Client,
-    image_ref: &oci_distribution::Reference,
-) -> Result<(String, OciDescriptor)> {
-    let (manifest, digest) = client.pull_manifest(image_ref).await?;
-    let mut layers = manifest.layers;
-    let orig_layer_count = layers.len();
-    layers.retain(|layer| {
-        matches!(
-            layer.media_type.as_str(),
-            super::oci::DOCKER_TYPE_LAYER | oci_distribution::manifest::IMAGE_LAYER_GZIP_MEDIA_TYPE
-        )
-    });
-    let n = layers.len();
+fn find_layer_blobid(manifest: &oci::Manifest) -> Result<String> {
+    let layers: Vec<_> = manifest
+        .layers
+        .iter()
+        .filter(|&layer| {
+            matches!(
+                layer.media_type.as_str(),
+                super::oci::DOCKER_TYPE_LAYER | oci::OCI_TYPE_LAYER
+            )
+        })
+        .collect();
 
+    let n = layers.len();
     if let Some(layer) = layers.into_iter().next() {
         if n > 1 {
             Err(anyhow!("Expected 1 layer, found {}", n))
         } else {
-            Ok((digest, layer))
+            let digest = layer.digest.as_str();
+            let hash = digest
+                .strip_prefix("sha256:")
+                .ok_or_else(|| anyhow!("Expected sha256: in digest: {}", digest))?;
+            Ok(hash.into())
         }
     } else {
-        Err(anyhow!("No layers found (orig: {})", orig_layer_count))
+        Err(anyhow!("No layers found (orig: {})", manifest.layers.len()))
     }
 }
 
 #[allow(unsafe_code)]
-#[context("Importing {}", image_ref)]
-async fn import_impl(repo: &ostree::Repo, image_ref: &str) -> Result<Import> {
-    let image_ref: oci_distribution::Reference = image_ref.parse()?;
-    let client = &mut oci_distribution::Client::default();
-    let auth = &oci_distribution::secrets::RegistryAuth::Anonymous;
-    client
-        .auth(
-            &image_ref,
-            auth,
-            &oci_distribution::secrets::RegistryOperation::Pull,
-        )
-        .await?;
-    let (image_digest, layer) = fetch_layer_descriptor(client, &image_ref).await?;
-
-    let req = client
-        .request_layer(&image_ref, &layer.digest)
-        .await?
-        .bytes_stream();
+#[context("Importing {}", imgref)]
+async fn import_impl(repo: &ostree::Repo, imgref: &str) -> Result<Import> {
+    let imgref: oci_distribution::Reference = imgref
+        .try_into()
+        .context("Failed to parse image reference")?;
+    let (manifest, image_digest) = fetch_manifest(&imgref).await?;
+    let manifest = &manifest;
+    let layerid = find_layer_blobid(manifest)?;
+    let (archive_in, fetch_worker) = fetch_oci_archive(&imgref).await?;
+    let (blob, parse_worker) = read_oci_archive_blob(archive_in, layerid.as_str())?;
+    let blob = blob.await?;
     let (pipein, mut pipeout) = os_pipe::pipe()?;
     let copier = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-        let req = futures::executor::block_on_stream(req);
-        for v in req {
-            let v = v.map_err(anyhow::Error::msg).context("Writing buf")?;
-            pipeout.write_all(&v)?;
+        let mut content = blob
+            .content
+            .ok_or_else(|| anyhow!("Blob layer is not a regular file"))?;
+        while let Some(buf) = content.blocking_recv() {
+            let buf: bytes::Bytes = buf;
+            pipeout.write_all(&buf)?;
         }
         Ok(())
     });
@@ -76,7 +179,10 @@ async fn import_impl(repo: &ostree::Repo, image_ref: &str) -> Result<Import> {
         let gz = flate2::read::GzDecoder::new(pipein);
         crate::tar::import_tar(&repo, gz)
     });
-    let (import_res, copy_res) = tokio::join!(import, copier);
+    let (import_res, copy_res, fetch_worker, parse_worker) = tokio::join!(import, copier, fetch_worker, parse_worker);
+    dbg!(&import_res, &copy_res, &fetch_worker, &parse_worker);
+    fetch_worker?;
+    parse_worker?;
     copy_res??;
     let ostree_commit = import_res??;
 

--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -15,4 +15,5 @@ type Result<T> = anyhow::Result<T>;
 pub mod buildoci;
 pub mod client;
 
+mod asynctar;
 pub mod oci;

--- a/lib/src/container/oci.rs
+++ b/lib/src/container/oci.rs
@@ -16,9 +16,9 @@ static MACHINE_TO_OCI: phf::Map<&str, &str> = phf_map! {
 };
 
 // OCI types, see https://github.com/opencontainers/image-spec/blob/master/media-types.md
-const OCI_TYPE_CONFIG_JSON: &str = "application/vnd.oci.image.config.v1+json";
-const OCI_TYPE_MANIFEST_JSON: &str = "application/vnd.oci.image.manifest.v1+json";
-const OCI_TYPE_LAYER: &str = "application/vnd.oci.image.layer.v1.tar+gzip";
+pub(crate) const OCI_TYPE_CONFIG_JSON: &str = "application/vnd.oci.image.config.v1+json";
+pub(crate) const OCI_TYPE_MANIFEST_JSON: &str = "application/vnd.oci.image.manifest.v1+json";
+pub(crate) const OCI_TYPE_LAYER: &str = "application/vnd.oci.image.layer.v1.tar+gzip";
 
 pub(crate) const DOCKER_TYPE_LAYER: &str = "application/vnd.docker.image.rootfs.diff.tar.gzip";
 
@@ -28,7 +28,6 @@ const BLOBDIR: &str = "blobs/sha256";
 fn default_schema_version() -> u32 {
     2
 }
-
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct IndexPlatform {

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -13,7 +13,6 @@
 /// to a string to output to a terminal or logs.
 type Result<T> = anyhow::Result<T>;
 
-#[cfg(feature = "container")]
 pub mod container;
 pub mod diff;
 pub mod ostree_ext;


### PR DESCRIPTION
The goal here is to implement: https://github.com/ostreedev/ostree-rs-ext/issues/6

We want to honor things like mirroring set up in `/etc/containers`.

However, after doing all this work I hit on two things:

- containers/image barfs if the destination is a pipe
- And actually even if we ask to copy into an `oci-archive` it still
  spools everything to a temporary directory and then tars it
  back up, entirely obviating the point of streaming.