### PR TITLE
Make tar import API async

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.1.0"
 
 [dependencies]
 anyhow = "1.0"
+async-compression = { version = "0.3.8", features = ["tokio", "gzip"] }
 bytes = "1.0.1"
 camino = "1.0.4"
 fn-error-context = "0.1.1"

--- a/lib/src/async_util.rs
+++ b/lib/src/async_util.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+use futures::prelude::*;
+use std::io::prelude::*;
+use tokio::io::AsyncRead;
+
+/// Bridge from AsyncRead to Read.
+///
+/// This creates a pipe and a "driver" future (which could be spawned or not).
+pub(crate) fn copy_async_read_to_sync_pipe<S: AsyncRead + Unpin + Send + 'static>(
+    s: S,
+) -> Result<(impl Read, impl Future<Output = Result<()>>)> {
+    let (pipein, mut pipeout) = os_pipe::pipe()?;
+
+    let copier = async move {
+        let mut input = tokio_util::io::ReaderStream::new(s).boxed();
+        while let Some(buf) = input.next().await {
+            let buf = buf?;
+            // TODO blocking executor
+            pipeout.write_all(&buf)?;
+        }
+        Ok::<_, anyhow::Error>(())
+    };
+
+    Ok((pipein, copier))
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -13,6 +13,7 @@
 /// to a string to output to a terminal or logs.
 type Result<T> = anyhow::Result<T>;
 
+mod async_util;
 pub mod container;
 pub mod diff;
 pub mod ostree_ext;


### PR DESCRIPTION
We're currently using the synchronous tar library, so we need to
do bridging.  This pushes the bridging down a layer, changing
our tar import API to be async.

Then things will be even clear if we switch to e.g.
https://crates.io/crates/tokio-tar

But we need https://github.com/vorot93/tokio-tar/pull/3