### PR TITLE
container: Use docker-archive: to stream image

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -28,6 +28,7 @@ ostree-sys = "0.7.2"
 tar = "0.4.33"
 tempfile = "3.2.0"
 tracing = "0.1"
+tokio-stream = "0.1.5"
 
 [dependencies.cjson]
 version = "0.1.1"

--- a/lib/src/container/skopeo.rs
+++ b/lib/src/container/skopeo.rs
@@ -8,6 +8,7 @@ use tokio::process::Command;
 /// Create a Command builder for skopeo.
 pub(crate) fn new_cmd() -> tokio::process::Command {
     let mut cmd = Command::new("skopeo");
+    cmd.stdin(Stdio::null());
     cmd.kill_on_drop(true);
     cmd
 }


### PR DESCRIPTION
Depends: https://github.com/ostreedev/ostree-rs-ext/pull/20 (mostly to avoid conflicts)

container: Use docker-archive: to stream image

It turns out that for whatever reasons (presumably mostly historical)
in skopeo, while `oci-archive:` is backed by just writing everything
to a tempdir and then tarring it up, the `docker-archive:` format
is actually streaming.

And it's *way* nicer and more efficient to stream.  Then the
last piece of this puzzle is that I realized we can use a named pipe
i.e. `mkfifo` to avoid having the containers/image stack crash
because it wants to invoke `realpath()` on the provided target.
By simply giving our pipe a name, it can do so (though it's
pointless) but this way we work with shipped versions of skopeo
and don't need to wait months for patches to propagate.

Also as a bonus, here skopeo ends up decompressing the layer for us,
so we don't need to e.g. handle gzip vs zstd in our code.
