### PR TITLE
Fix async -> sync read bridge

### DIFF
--- a/lib/src/tar/import.rs
+++ b/lib/src/tar/import.rs
@@ -463,7 +463,7 @@ pub async fn import_tar(
     repo: &ostree::Repo,
     src: impl tokio::io::AsyncRead + Send + Unpin + 'static,
 ) -> Result<String> {
-    let (pipein, copydriver) = crate::async_util::copy_async_read_to_sync_pipe(src)?;
+    let pipein = crate::async_util::async_read_to_sync(src);
     let repo = repo.clone();
     let import = tokio::task::spawn_blocking(move || {
         let repo = &repo;
@@ -503,8 +503,7 @@ pub async fn import_tar(
         importer.commit()
     })
     .map_err(anyhow::Error::msg);
-    let (import, _copydriver) = tokio::try_join!(import, copydriver)?;
-    let import = import?;
+    let import: String = import.await??;
     Ok(import)
 }
 


### PR DESCRIPTION
Followup to https://users.rust-lang.org/t/best-practices-for-bridging-async-and-sync-particularly-read-write/58994/2

This is *way* simpler and more obviously correct, and faster I'd imagine.

Now the caller doesn't need to juggle two futures, which simplifies
things there a lot.  This unearthed a bug in the container import
code where we really need to read to the end, otherwise skopeo
gets an `EPIPE`.