### PR TITLE
Release 0.1.2

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ostree-ext-cli"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-ext"
-version = "0.1.1"
+version = "0.1.2"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Mainly adds `container export containers-storage:` which is
going to be very useful for things like CI tests, and also helps
complete the picture of bidirectional mapping between ostree
and containers.