### PR TITLE
lib: Link to zlib

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -33,6 +33,8 @@ version = "0.1.1"
 
 [dependencies.flate2]
 version = "1.0.20"
+features = ["zlib"]
+default-features = false
 
 [dependencies.futures]
 version = "0.3.13"


### PR DESCRIPTION
It's going to be more tuned for e.g. target CPU than the Rust
version, and we already link to it in process.