### PR TITLE
oci: Generate correct uncompressed hash

### DIFF
--- a/lib/src/container/oci.rs
+++ b/lib/src/container/oci.rs
@@ -312,6 +312,6 @@ impl<'a> std::io::Write for LayerWriter<'a> {
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
+        self.bw.flush()
     }
 }

--- a/lib/src/container/oci.rs
+++ b/lib/src/container/oci.rs
@@ -305,6 +305,7 @@ impl<'a> std::io::Write for LayerWriter<'a> {
     fn write(&mut self, srcbuf: &[u8]) -> std::io::Result<usize> {
         self.compressor.get_mut().clear();
         self.compressor.write_all(srcbuf).unwrap();
+        self.uncompressed_hash.update(srcbuf)?;
         let compressed_buf = self.compressor.get_mut().as_slice();
         self.bw.write_all(&compressed_buf)?;
         Ok(srcbuf.len())

--- a/lib/src/container/oci.rs
+++ b/lib/src/container/oci.rs
@@ -183,6 +183,7 @@ impl<'a> OciWriter<'a> {
         if let Some(cmd) = self.cmd.as_deref() {
             ctrconfig.insert("Cmd".to_string(), serde_json::to_value(cmd)?);
         }
+        let created_by = concat!("created by ", env!("CARGO_PKG_VERSION"));
         let config = serde_json::json!({
             "architecture": arch,
             "os": "linux",
@@ -193,7 +194,7 @@ impl<'a> OciWriter<'a> {
             },
             "history": [
                 {
-                    "commit": "created by ostree-container",
+                    "commit": created_by,
                 }
             ]
         });


### PR DESCRIPTION
oci: Add crate name/version in history

For debugging purposes.

---

oci: Generate correct uncompressed hash

I broke this in a refactoring, turns out `docker` checks it
but `podman` doesn't (which seems to clearly be a bug).

Reported on chat by someone trying out running
via `docker`.

---

