### PR TITLE
ci fixes and cargo fmt

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,14 +16,12 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    container: quay.io/cgwalters/fcos-buildroot
+    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
 
     steps:
     - name: Install skopeo
       run: yum -y install skopeo
     - uses: actions/checkout@v2
-    - name: Hack in updated ostree
-      run: rpm -Uvh https://kojipkgs.fedoraproject.org//packages/ostree/2021.2/2.fc33/x86_64/ostree-{,devel-,libs-}2021.2-2.fc33.x86_64.rpm
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,8 @@ jobs:
     - name: Install skopeo
       run: yum -y install skopeo
     - uses: actions/checkout@v2
+    - name: Format
+      run: cargo fmt -- --check -l
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -93,7 +93,7 @@ enum ContainerOpts {
         imgref: String,
 
         /// Additional labels for the container
-        #[structopt(name="label", long, short)]
+        #[structopt(name = "label", long, short)]
         labels: Vec<String>,
 
         /// Corresponds to the Dockerfile `CMD` instruction.

--- a/lib/src/container/oci.rs
+++ b/lib/src/container/oci.rs
@@ -179,7 +179,10 @@ impl<'a> OciWriter<'a> {
         let root_layer_id = format!("sha256:{}", rootfs_blob.uncompressed_sha256);
 
         let mut ctrconfig = serde_json::Map::new();
-        ctrconfig.insert("Labels".to_string(), serde_json::to_value(&self.config_annotations)?);
+        ctrconfig.insert(
+            "Labels".to_string(),
+            serde_json::to_value(&self.config_annotations)?,
+        );
         if let Some(cmd) = self.cmd.as_deref() {
             ctrconfig.insert("Cmd".to_string(), serde_json::to_value(cmd)?);
         }


### PR DESCRIPTION
ci: Use latest buildroot, drop ostree override

The latest official buildroot has what we need.

---

Run `cargo fmt` and add ci check

---

