### PR TITLE
variant_utils: Add helpers for strv/`as`

### DIFF
--- a/lib/src/variant_utils.rs
+++ b/lib/src/variant_utils.rs
@@ -84,10 +84,16 @@ pub fn new_variant_a_ayay<T: AsRef<[u8]>>(items: &[(T, T)]) -> glib::Variant {
 
 /// Create a new GVariant of type `as`.  
 pub fn new_variant_as(items: &[&str]) -> glib::Variant {
+    new_variant_as_fromiter(items.iter().map(|&s| s))
+}
+
+/// Create a new GVariant of type `as` from an iterator.
+pub fn new_variant_as_fromiter<'a>(items: impl IntoIterator<Item = &'a str>) -> glib::Variant {
+    let items = items.into_iter();
     unsafe {
         let ty = glib::VariantTy::new("as").unwrap();
         let builder = glib_sys::g_variant_builder_new(ty.as_ptr() as *const _);
-        for &k in items {
+        for k in items {
             let k = k.to_variant();
             glib_sys::g_variant_builder_add_value(builder, k.to_glib_none().0);
         }
@@ -98,11 +104,48 @@ pub fn new_variant_as(items: &[&str]) -> glib::Variant {
 }
 
 /// Extension trait for `glib::VariantDict`.
+pub trait VariantExt {
+    /// Get a value of type `as` (array of strings).
+    fn get_strv(&self) -> Option<Vec<&str>>;
+}
+
+impl VariantExt for glib::Variant {
+    fn get_strv(&self) -> Option<Vec<&str>> {
+        let v = self.to_glib_none();
+        match self.type_().to_str() {
+            "as" => {
+                let n = unsafe { glib_sys::g_variant_n_children(v.0) };
+                let mut r = Vec::with_capacity(n);
+                for i in 0..n {
+                    // SAFETY: We checked the index above
+                    let child = variant_get_child_value(self, i).unwrap();
+                    let mut len = 0;
+                    // SAFETY: We know it's of type `s`, and the data is owned by &self
+                    let s = unsafe {
+                        let ptr = glib_sys::g_variant_get_string(child.to_glib_none().0, &mut len);
+                        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+                            ptr as *const u8,
+                            len as usize,
+                        ))
+                    };
+                    r.push(s);
+                }
+                Some(r)
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Extension trait for `glib::VariantDict`.
 pub trait VariantDictExt {
     /// Find (and duplicate) a string-valued key in this dictionary.
     fn lookup_str(&self, k: &str) -> Option<String>;
     /// Find a `bool`-valued key in this dictionary.
     fn lookup_bool(&self, k: &str) -> Option<bool>;
+
+    /// Insert a value of type `as`.
+    fn insert_as<'a>(&self, k: &str, v: impl IntoIterator<Item = &'a str>);
 }
 
 impl VariantDictExt for glib::VariantDict {
@@ -116,6 +159,11 @@ impl VariantDictExt for glib::VariantDict {
         // Unwrap safety: Passing the GVariant type string gives us the right value type
         self.lookup_value(k, Some(glib::VariantTy::new("b").unwrap()))
             .map(|v| v.get().unwrap())
+    }
+
+    fn insert_as<'a>(&self, k: &str, v: impl IntoIterator<Item = &'a str>) {
+        let v = new_variant_as_fromiter(v);
+        self.insert_value(k, &v)
     }
 }
 
@@ -138,20 +186,24 @@ mod tests {
         let d = glib::VariantDict::new(None);
         d.insert("foo", &"bar");
         assert_eq!(d.lookup_str("foo"), Some("bar".to_string()));
+
+        let strv = ["one", "two"];
+        d.insert_as("testas", strv.iter().map(|&s| s));
+        let v = &d
+            .lookup_value("testas", Some(glib::VariantTy::new("as").unwrap()))
+            .unwrap();
+
+        assert_eq!(v.get_strv().unwrap(), strv);
     }
 
     #[test]
     fn test_variant_as() {
         let _ = new_variant_as(&[]);
-        let v = new_variant_as(&["foo", "bar"]);
-        assert_eq!(
-            variant_get_child_value(&v, 0).unwrap().get_str().unwrap(),
-            "foo"
-        );
-        assert_eq!(
-            variant_get_child_value(&v, 1).unwrap().get_str().unwrap(),
-            "bar"
-        );
-        assert!(variant_get_child_value(&v, 2).is_none());
+        let strv = &["foo", "bar"];
+        let v = new_variant_as(strv);
+        assert_eq!(v.get_strv().unwrap(), strv);
+
+        let v = glib::Variant::from(true);
+        assert!(v.get_strv().is_none());
     }
 }


### PR DESCRIPTION
We use this type extensively, so let's add some convenience API.

This should go away with glib 0.14, but that's a nontrivial port.