### PR TITLE
Release 0.2.0

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ostree-ext-cli"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-ext"
-version = "0.1.4"
+version = "0.2.0"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Breaking changes:

- glib 0.14
- Removed most now unnecessary bits from `variant_utils`