### PR TITLE
Release 0.2.1

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-ext"
-version = "0.2.0"
+version = "0.2.1"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
To pull in the updated deps, to avoid having lots more to vendor
for rpm-ostree.