### PR TITLE
Use gio via `ostree::gio`

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,7 +15,6 @@ structopt = "0.3.21"
 ostree = { version = "0.12.0", features = ["v2021_2"] }
 libc = "0.2.92"
 tokio = { version = "1", features = ["full"] }
-gio = "0.14"
 log = "0.4.0"
 tracing = "0.1"
 tracing-subscriber = "0.2.17"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,7 +16,6 @@ cjson = "0.1.1"
 flate2 = { features = ["zlib"], default_features = false, version = "1.0.20" }
 fn-error-context = "0.2.0"
 futures = "0.3.13"
-gio = "0.14"
 gvariant = "0.4.0"
 hex = "0.4.3"
 indicatif = "0.16.0"

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -6,6 +6,7 @@
 //! such as `rpm-ostree` can directly reuse it.
 
 use anyhow::Result;
+use ostree::gio;
 use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::ffi::OsString;

--- a/lib/src/container/export.rs
+++ b/lib/src/container/export.rs
@@ -5,6 +5,7 @@ use crate::tar as ostree_tar;
 use anyhow::Context;
 use fn_error_context::context;
 use gio::glib;
+use ostree::gio;
 use std::collections::BTreeMap;
 use std::path::Path;
 use tracing::{instrument, Level};

--- a/lib/src/diff.rs
+++ b/lib/src/diff.rs
@@ -9,6 +9,7 @@
 use anyhow::{Context, Result};
 use fn_error_context::context;
 use gio::prelude::*;
+use ostree::gio;
 use std::collections::BTreeSet;
 use std::fmt;
 

--- a/lib/src/ima.rs
+++ b/lib/src/ima.rs
@@ -12,6 +12,7 @@ use glib::Variant;
 use gvariant::aligned_bytes::TryAsAligned;
 use gvariant::{gv, Marker, Structure};
 use openat_ext::FileExt;
+use ostree::gio;
 use std::collections::{BTreeMap, HashMap};
 use std::ffi::CString;
 use std::fs::File;

--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -8,6 +8,7 @@ use gio::glib;
 use gio::prelude::*;
 use gvariant::aligned_bytes::TryAsAligned;
 use gvariant::{gv, Marker, Structure};
+use ostree::gio;
 use std::borrow::Cow;
 use std::collections::HashSet;
 use std::io::BufReader;

--- a/lib/src/tar/import.rs
+++ b/lib/src/tar/import.rs
@@ -8,6 +8,7 @@ use futures::prelude::*;
 use gio::glib;
 use gio::prelude::*;
 use glib::Variant;
+use ostree::gio;
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::io::prelude::*;

--- a/lib/src/variant_utils.rs
+++ b/lib/src/variant_utils.rs
@@ -5,6 +5,7 @@
 
 use gio::glib;
 use glib::translate::*;
+use ostree::gio;
 
 /// Get the normal form of a GVariant.
 pub fn variant_get_normal_form(v: &glib::Variant) -> glib::Variant {

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use fn_error_context::context;
 use indoc::indoc;
+use ostree::gio;
 use ostree_ext::container::{Config, ImageReference, Transport};
 use sh_inline::bash;
 use std::{io::Write, process::Command};


### PR DESCRIPTION
By using the re-export, we avoid needing to keep a version lock
between glib and glib-sys in our main crate.  This helps
dependabot, etc.