### PR TITLE
Re-export our dependencies (`ostree`, `gio`, `glib`) and add a prelude

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,7 +12,6 @@ anyhow = "1.0"
 ostree-ext = { path = "../lib" }
 clap = "2.33.3"
 structopt = "0.3.21"
-ostree = { version = "0.12.0", features = ["v2021_2"] }
 libc = "0.2.92"
 tokio = { version = "1", features = ["full"] }
 log = "0.4.0"

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -10,6 +10,13 @@
 #![deny(unsafe_code)]
 #![cfg_attr(feature = "dox", feature(doc_cfg))]
 
+// Re-export our dependencies.  See https://gtk-rs.org/blog/2021/06/22/new-release.html
+// "Dependencies are re-exported".  Users will need e.g. `gio::File`, so this avoids
+// them needing to update matching versions.
+pub use ostree;
+pub use ostree::gio;
+pub use ostree::gio::glib;
+
 /// Our generic catchall fatal error, expected to be converted
 /// to a string to output to a terminal or logs.
 type Result<T> = anyhow::Result<T>;
@@ -22,3 +29,9 @@ pub mod ima;
 pub mod tar;
 #[allow(unsafe_code)]
 pub mod variant_utils;
+
+/// Prelude, intended for glob import.
+pub mod prelude {
+    #[doc(hidden)]
+    pub use ostree::prelude::*;
+}

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -2,8 +2,8 @@ use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use fn_error_context::context;
 use indoc::indoc;
-use ostree::gio;
 use ostree_ext::container::{Config, ImageReference, Transport};
+use ostree_ext::gio;
 use sh_inline::bash;
 use std::{io::Write, process::Command};
 


### PR DESCRIPTION
This is the equivalent of https://github.com/ostreedev/ostree-rs/pull/13/commits/a1e5bc3f320a28b3a7fd80b9a7f6b0ff76540a23

This allows our users to avoid adding explicit dependencies on
those libraries, because in practice e.g. `ostree` and `gio`
must be versioned together.