### PR TITLE
Release 0.2.2

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
```
Colin Walters (8):
      oci: Pass through other architectures
      Use glib-sys via re-exported glib::ffi
      Use `glib` via re-export from `gio`
      ima: Use new GVariant code, drop unsafe
      Use gio via `ostree::gio`
      Try to fix the docs.rs build
      Re-export our dependencies (`ostree`, `gio`, `glib`) and add a prelude
      Release 0.2.2

Luca BRUNO (1):
      cargo: fix repository location

```