### PR TITLE
tar: Correctly pass import/export commit metadata

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -32,3 +32,36 @@ pub mod prelude {
     #[doc(hidden)]
     pub use ostree::prelude::*;
 }
+
+/// Temporary holding place for fixed APIs
+#[allow(unsafe_code)]
+mod ostree_ffi_fixed {
+    use super::*;
+    use ostree::prelude::*;
+
+    /// https://github.com/ostreedev/ostree/pull/2422
+    pub(crate) fn read_commit_detached_metadata<P: IsA<gio::Cancellable>>(
+        repo: &ostree::Repo,
+        checksum: &str,
+        cancellable: Option<&P>,
+    ) -> std::result::Result<Option<glib::Variant>, glib::Error> {
+        use glib::translate::*;
+        use std::ptr;
+        unsafe {
+            let mut out_metadata = ptr::null_mut();
+            let mut error = ptr::null_mut();
+            let _ = ostree::ffi::ostree_repo_read_commit_detached_metadata(
+                repo.to_glib_none().0,
+                checksum.to_glib_none().0,
+                &mut out_metadata,
+                cancellable.map(|p| p.as_ref()).to_glib_none().0,
+                &mut error,
+            );
+            if error.is_null() {
+                Ok(from_glib_full(out_metadata))
+            } else {
+                Err(from_glib_full(error))
+            }
+        }
+    }
+}

--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -62,7 +62,7 @@ impl<'a, W: std::io::Write> OstreeMetadataWriter<'a, W> {
         v: &glib::Variant,
     ) -> Result<()> {
         let set = match objtype {
-            ostree::ObjectType::Commit => None,
+            ostree::ObjectType::Commit | ostree::ObjectType::CommitMeta => None,
             ostree::ObjectType::DirTree => Some(&mut self.wrote_dirtree),
             ostree::ObjectType::DirMeta => Some(&mut self.wrote_dirmeta),
             o => panic!("Unexpected object type: {:?}", o),
@@ -266,7 +266,7 @@ fn impl_export<W: std::io::Write>(
     writer.append(ostree::ObjectType::Commit, commit_checksum, commit_v)?;
 
     if let Some(commitmeta) =
-        repo.load_variant_if_exists(ostree::ObjectType::CommitMeta, commit_checksum)?
+        crate::ostree_ffi_fixed::read_commit_detached_metadata(repo, commit_checksum, cancellable)?
     {
         writer.append(ostree::ObjectType::CommitMeta, commit_checksum, &commitmeta)?;
     }

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -22,7 +22,7 @@ fn generate_test_repo(dir: &Utf8Path) -> Result<Utf8PathBuf> {
         indoc! {"
         cd {dir}
         ostree --repo=repo init --mode=archive
-        ostree --repo=repo commit -b {testref} --bootable --add-metadata-string=version=42.0 --tree=tar=exampleos.tar.zst
+        ostree --repo=repo commit -b {testref} --bootable --add-metadata-string=version=42.0 --add-detached-metadata-string=my-detached-key=my-detached-value --tree=tar=exampleos.tar.zst
         ostree --repo=repo show {testref}
     "},
         testref = TESTREF,
@@ -93,7 +93,11 @@ async fn test_tar_import_export() -> Result<()> {
             .as_str()
     );
     bash!(
-        "ostree --repo={destrepodir} ls -R {imported_commit}",
+        r#"
+         ostree --repo={destrepodir} ls -R {imported_commit}
+         val=$(ostree --repo={destrepodir} show --print-detached-metadata-key=my-detached-key {imported_commit})
+         test "${{val}}" = "'my-detached-value'"
+        "#,
         destrepodir = destrepodir.as_str(),
         imported_commit = imported_commit.as_str()
     )?;


### PR DESCRIPTION
There were multiple bugs here.

Prep for implementing signing:
https://github.com/ostreedev/ostree-rs-ext/issues/2