### PR TITLE
Prep release 0.3.0

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
-version = "0.2.2"
+version = "0.3.0"
 
 [dependencies]
 anyhow = "1.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -24,7 +24,7 @@ nix = "0.22.0"
 openat = "0.1.20"
 openat-ext = "0.2.0"
 openssl = "0.10.33"
-ostree = { features = ["v2021_2"], version = "0.12.0" }
+ostree = { features = ["v2021_2"], version = "0.13.0" }
 phf = { features = ["macros"], version = "0.9.0" }
 serde = { features = ["derive"], version = "1.0.125" }
 serde_json = "1.0.64"

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -32,36 +32,3 @@ pub mod prelude {
     #[doc(hidden)]
     pub use ostree::prelude::*;
 }
-
-/// Temporary holding place for fixed APIs
-#[allow(unsafe_code)]
-mod ostree_ffi_fixed {
-    use super::*;
-    use ostree::prelude::*;
-
-    /// https://github.com/ostreedev/ostree/pull/2422
-    pub(crate) fn read_commit_detached_metadata<P: IsA<gio::Cancellable>>(
-        repo: &ostree::Repo,
-        checksum: &str,
-        cancellable: Option<&P>,
-    ) -> std::result::Result<Option<glib::Variant>, glib::Error> {
-        use glib::translate::*;
-        use std::ptr;
-        unsafe {
-            let mut out_metadata = ptr::null_mut();
-            let mut error = ptr::null_mut();
-            let _ = ostree::ffi::ostree_repo_read_commit_detached_metadata(
-                repo.to_glib_none().0,
-                checksum.to_glib_none().0,
-                &mut out_metadata,
-                cancellable.map(|p| p.as_ref()).to_glib_none().0,
-                &mut error,
-            );
-            if error.is_null() {
-                Ok(from_glib_full(out_metadata))
-            } else {
-                Err(from_glib_full(error))
-            }
-        }
-    }
-}

--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -265,9 +265,7 @@ fn impl_export<W: std::io::Write>(
     let commit_v = &commit_v;
     writer.append(ostree::ObjectType::Commit, commit_checksum, commit_v)?;
 
-    if let Some(commitmeta) =
-        crate::ostree_ffi_fixed::read_commit_detached_metadata(repo, commit_checksum, cancellable)?
-    {
+    if let Some(commitmeta) = repo.read_commit_detached_metadata(commit_checksum, cancellable)? {
         writer.append(ostree::ObjectType::CommitMeta, commit_checksum, &commitmeta)?;
     }
 


### PR DESCRIPTION
lib: Bump to 0.3

We're going to make some semver-incompatible changes.

---

lib: Bump to ostree 0.9

We can drop our FFI workaround.

---

