### PR TITLE
lib: Only depend on futures-util

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -15,7 +15,7 @@ camino = "1.0.4"
 cjson = "0.1.1"
 flate2 = { features = ["zlib"], default_features = false, version = "1.0.20" }
 fn-error-context = "0.2.0"
-futures = "0.3.13"
+futures-util = "0.3.13"
 gvariant = "0.4.0"
 hex = "0.4.3"
 indicatif = "0.16.0"

--- a/lib/src/container/import.rs
+++ b/lib/src/container/import.rs
@@ -4,7 +4,7 @@ use super::*;
 use anyhow::{anyhow, Context};
 use camino::Utf8Path;
 use fn_error_context::context;
-use futures::prelude::*;
+use futures_util::{Future, FutureExt, TryFutureExt};
 use std::io::prelude::*;
 use std::pin::Pin;
 use std::process::Stdio;

--- a/lib/src/tar/import.rs
+++ b/lib/src/tar/import.rs
@@ -4,7 +4,7 @@ use crate::Result;
 use anyhow::{anyhow, Context};
 use camino::Utf8Path;
 use fn_error_context::context;
-use futures::prelude::*;
+use futures_util::TryFutureExt;
 use gio::glib;
 use gio::prelude::*;
 use glib::Variant;


### PR DESCRIPTION
I saw this in https://www.reddit.com/r/rust/comments/pkr9aa/is_the_crate_dependency_becoming_a_problem/

That said it turns out `glib` is depending on `futures-executor` right
now too.