### PR TITLE
lib/container: Introduce OstreeImageReference

### DIFF
--- a/lib/src/container/export.rs
+++ b/lib/src/container/export.rs
@@ -122,9 +122,13 @@ async fn build_impl(
             return Err(anyhow::anyhow!("skopeo failed: {}\n", stderr));
         }
     }
+    let imgref = OstreeImageReference {
+        sigverify: SignatureSource::ContainerPolicyAllowInsecure,
+        imgref: dest.to_owned(),
+    };
     // FIXME - it's obviously broken to do this push -> inspect cycle because of the possibility
     // of a race condition, but we need to patch skopeo to have the equivalent of `podman push --digestfile`.
-    let info = super::import::fetch_manifest_info(dest).await?;
+    let info = super::import::fetch_manifest_info(&imgref).await?;
     Ok(dest.with_digest(info.manifest_digest.as_str()))
 }
 

--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -40,12 +40,35 @@ pub enum Transport {
 /// Combination of a remote image reference and transport.
 ///
 /// For example,
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ImageReference {
     /// The storage and transport for the image
     pub transport: Transport,
     /// The image name (e.g. `quay.io/somerepo/someimage:latest`)
     pub name: String,
+}
+
+/// Policy for signature verification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SignatureSource {
+    /// Fetches will use the named ostree remote for signature verification of the ostree commit.
+    OstreeRemote(String),
+    /// Fetches will defer to the `containers-policy.json`, but we make a best effort to reject `default: insecureAcceptAnything` policy.
+    ContainerPolicy,
+    /// NOT RECOMMENDED.  Fetches will defer to the `containers-policy.json` default which is usually `insecureAcceptAnything`.
+    ContainerPolicyAllowInsecure,
+}
+
+/// Combination of an ostree remote (for signature verification) and an image reference.
+///
+/// For example, myremote:docker://quay.io/somerepo/someimage.latest
+#[derive(Debug, Clone)]
+pub struct OstreeImageReference {
+    /// The ostree remote name.
+    /// This will be used for signature verification.
+    pub sigverify: SignatureSource,
+    /// The container image reference.
+    pub imgref: ImageReference,
 }
 
 impl ImageReference {
@@ -69,6 +92,23 @@ impl ImageReference {
         Self {
             transport: self.transport,
             name: format!("{}@{}", name, digest),
+        }
+    }
+}
+
+impl OstreeImageReference {
+    /// Create a new `OstreeImageReference` that refers to a specific digest.
+    ///
+    /// ```rust
+    /// use std::convert::TryInto;
+    /// let r: ostree_ext::container::OstreeImageReference = "ostree-remote-image:myremote:docker://quay.io/exampleos/exampleos:latest".try_into().unwrap();
+    /// let n = r.with_digest("sha256:41af286dc0b172ed2f1ca934fd2278de4a1192302ffa07087cea2682e7d372e3");
+    /// assert_eq!(n.imgref.name, "quay.io/exampleos/exampleos@sha256:41af286dc0b172ed2f1ca934fd2278de4a1192302ffa07087cea2682e7d372e3");
+    /// ```
+    pub fn with_digest(&self, digest: &str) -> Self {
+        Self {
+            sigverify: self.sigverify.clone(),
+            imgref: self.imgref.with_digest(digest),
         }
     }
 }
@@ -112,6 +152,52 @@ impl TryFrom<&str> for ImageReference {
     }
 }
 
+impl TryFrom<&str> for SignatureSource {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> Result<Self> {
+        match value {
+            "ostree-image-signed" => Ok(Self::ContainerPolicy),
+            "ostree-unverified-image" => Ok(Self::ContainerPolicyAllowInsecure),
+            o => match o.strip_prefix("ostree-remote-image:") {
+                Some(rest) => Ok(Self::OstreeRemote(rest.to_string())),
+                _ => Err(anyhow!("Invalid signature source: {}", o)),
+            },
+        }
+    }
+}
+
+impl TryFrom<&str> for OstreeImageReference {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> Result<Self> {
+        let mut parts = value.splitn(2, ':');
+        // Safety: Split always returns at least one value.
+        let first = parts.next().unwrap();
+        let mut second = parts
+            .next()
+            .ok_or_else(|| anyhow!("Missing ':' in {}", value))?;
+        let sigverify = match first {
+            "ostree-image-signed" => SignatureSource::ContainerPolicy,
+            "ostree-unverified-image" => SignatureSource::ContainerPolicyAllowInsecure,
+            "ostree-remote-image" => {
+                let mut subparts = second.splitn(2, ':');
+                // Safety: Split always returns at least one value.
+                let remote = subparts.next().unwrap();
+                second = subparts
+                    .next()
+                    .ok_or_else(|| anyhow!("Missing second ':' in {}", value))?;
+                SignatureSource::OstreeRemote(remote.to_string())
+            }
+            o => {
+                return Err(anyhow!("Invalid signature source: {}", o));
+            }
+        };
+        let imgref = second.try_into()?;
+        Ok(Self { sigverify, imgref })
+    }
+}
+
 impl std::fmt::Display for Transport {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
@@ -128,6 +214,20 @@ impl std::fmt::Display for Transport {
 impl std::fmt::Display for ImageReference {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}{}", self.transport, self.name)
+    }
+}
+
+impl std::fmt::Display for OstreeImageReference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.sigverify {
+            SignatureSource::OstreeRemote(r) => {
+                write!(f, "ostree-remote-image:{}:{}", r, self.imgref)
+            }
+            SignatureSource::ContainerPolicy => write!(f, "ostree-image-signed:{}", self.imgref),
+            SignatureSource::ContainerPolicyAllowInsecure => {
+                write!(f, "ostree-unverified-image:{}", self.imgref)
+            }
+        }
     }
 }
 
@@ -179,5 +279,46 @@ mod tests {
         let ir: ImageReference = "oci:somedir".try_into().unwrap();
         assert_eq!(ir.transport, Transport::OciDir);
         assert_eq!(ir.name, "somedir");
+    }
+
+    #[test]
+    fn test_ostreeimagereference() {
+        let ir_s = "ostree-remote-image:myremote:registry:quay.io/exampleos/blah";
+        let ir: OstreeImageReference = ir_s.try_into().unwrap();
+        assert_eq!(
+            ir.sigverify,
+            SignatureSource::OstreeRemote("myremote".to_string())
+        );
+        assert_eq!(ir.imgref.transport, Transport::Registry);
+        assert_eq!(ir.imgref.name, "quay.io/exampleos/blah");
+        assert_eq!(
+            ir.to_string(),
+            "ostree-remote-image:myremote:docker://quay.io/exampleos/blah"
+        );
+
+        let digested = ir
+            .with_digest("sha256:41af286dc0b172ed2f1ca934fd2278de4a1192302ffa07087cea2682e7d372e3");
+        assert_eq!(digested.imgref.name, "quay.io/exampleos/blah@sha256:41af286dc0b172ed2f1ca934fd2278de4a1192302ffa07087cea2682e7d372e3");
+        assert_eq!(digested.with_digest("sha256:52f562806109f5746be31ccf21f5569fd2ce8c32deb0d14987b440ed39e34e20").imgref.name, "quay.io/exampleos/blah@sha256:52f562806109f5746be31ccf21f5569fd2ce8c32deb0d14987b440ed39e34e20");
+
+        let ir_s = "ostree-image-signed:docker://quay.io/exampleos/blah";
+        let ir: OstreeImageReference = ir_s.try_into().unwrap();
+        assert_eq!(ir.sigverify, SignatureSource::ContainerPolicy);
+        assert_eq!(ir.imgref.transport, Transport::Registry);
+        assert_eq!(ir.imgref.name, "quay.io/exampleos/blah");
+        assert_eq!(
+            ir.to_string(),
+            "ostree-image-signed:docker://quay.io/exampleos/blah"
+        );
+
+        let ir_s = "ostree-unverified-image:docker://quay.io/exampleos/blah";
+        let ir: OstreeImageReference = ir_s.try_into().unwrap();
+        assert_eq!(ir.sigverify, SignatureSource::ContainerPolicyAllowInsecure);
+        assert_eq!(ir.imgref.transport, Transport::Registry);
+        assert_eq!(ir.imgref.name, "quay.io/exampleos/blah");
+        assert_eq!(
+            ir.to_string(),
+            "ostree-unverified-image:docker://quay.io/exampleos/blah"
+        );
     }
 }

--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -42,7 +42,7 @@ pub enum Transport {
 /// Combination of a remote image reference and transport.
 ///
 /// For example,
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ImageReference {
     /// The storage and transport for the image
     pub transport: Transport,
@@ -64,7 +64,7 @@ pub enum SignatureSource {
 /// Combination of an ostree remote (for signature verification) and an image reference.
 ///
 /// For example, myremote:docker://quay.io/somerepo/someimage.latest
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OstreeImageReference {
     /// The ostree remote name.
     /// This will be used for signature verification.
@@ -322,6 +322,9 @@ mod tests {
         }
 
         let ir: OstreeImageReference = ir_s.try_into().unwrap();
+        // test our Eq implementation
+        assert_eq!(&ir, &OstreeImageReference::try_from(ir_registry).unwrap());
+
         let digested = ir
             .with_digest("sha256:41af286dc0b172ed2f1ca934fd2278de4a1192302ffa07087cea2682e7d372e3");
         assert_eq!(digested.imgref.name, "quay.io/exampleos/blah@sha256:41af286dc0b172ed2f1ca934fd2278de4a1192302ffa07087cea2682e7d372e3");

--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -185,6 +185,7 @@ impl TryFrom<&str> for OstreeImageReference {
                 SignatureSource::ContainerPolicyAllowInsecure,
                 Cow::Borrowed(second),
             ),
+            // This is a shorthand for ostree-remote-image with registry:
             "ostree-remote-registry" => {
                 let mut subparts = second.splitn(2, ':');
                 // Safety: Split always returns at least one value.

--- a/lib/src/container/skopeo.rs
+++ b/lib/src/container/skopeo.rs
@@ -6,6 +6,10 @@ use serde::Deserialize;
 use std::process::Stdio;
 use tokio::process::Command;
 
+// See `man containers-policy.json` and
+// https://github.com/containers/image/blob/main/signature/policy_types.go
+// Ideally we add something like `skopeo pull --disallow-insecure-accept-anything`
+// but for now we parse the policy.
 const POLICY_PATH: &str = "/etc/containers/policy.json";
 const INSECURE_ACCEPT_ANYTHING: &str = "insecureAcceptAnything";
 

--- a/lib/src/container/skopeo.rs
+++ b/lib/src/container/skopeo.rs
@@ -2,8 +2,41 @@
 
 use super::Result;
 use anyhow::Context;
+use serde::Deserialize;
 use std::process::Stdio;
 use tokio::process::Command;
+
+const POLICY_PATH: &str = "/etc/containers/policy.json";
+const INSECURE_ACCEPT_ANYTHING: &str = "insecureAcceptAnything";
+
+#[derive(Deserialize)]
+struct PolicyEntry {
+    #[serde(rename = "type")]
+    ty: String,
+}
+#[derive(Deserialize)]
+struct ContainerPolicy {
+    default: Option<Vec<PolicyEntry>>,
+}
+
+impl ContainerPolicy {
+    fn is_default_insecure(&self) -> bool {
+        if let Some(default) = self.default.as_deref() {
+            match default.split_first() {
+                Some((v, &[])) => return v.ty == INSECURE_ACCEPT_ANYTHING,
+                _ => false,
+            }
+        } else {
+            false
+        }
+    }
+}
+
+pub(crate) fn container_policy_is_default_insecure() -> Result<bool> {
+    let r = std::io::BufReader::new(std::fs::File::open(POLICY_PATH)?);
+    let policy: ContainerPolicy = serde_json::from_reader(r)?;
+    Ok(policy.is_default_insecure())
+}
 
 /// Create a Command builder for skopeo.
 pub(crate) fn new_cmd() -> tokio::process::Command {
@@ -17,4 +50,58 @@ pub(crate) fn new_cmd() -> tokio::process::Command {
 pub(crate) fn spawn(mut cmd: Command) -> Result<tokio::process::Child> {
     let cmd = cmd.stdin(Stdio::null()).stderr(Stdio::piped());
     cmd.spawn().context("Failed to exec skopeo")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Default value as of the Fedora 34 containers-common-1-21.fc34.noarch package.
+    const DEFAULT_POLICY: &str = indoc::indoc! {r#"
+    {
+        "default": [
+            {
+                "type": "insecureAcceptAnything"
+            }
+        ],
+        "transports":
+            {
+                "docker-daemon":
+                    {
+                        "": [{"type":"insecureAcceptAnything"}]
+                    }
+            }
+    }
+    "#};
+
+    // Stripped down copy from the manual.
+    const REASONABLY_LOCKED_DOWN: &str = indoc::indoc! { r#"
+    {
+        "default": [{"type": "reject"}],
+        "transports": {
+            "dir": {
+                "": [{"type": "insecureAcceptAnything"}]
+            },
+            "atomic": {
+                "hostname:5000/myns/official": [
+                    {
+                        "type": "signedBy",
+                        "keyType": "GPGKeys",
+                        "keyPath": "/path/to/official-pubkey.gpg"
+                    }
+                ]
+            }
+        }
+    }
+    "#};
+
+    #[test]
+    fn policy_is_insecure() {
+        let p: ContainerPolicy = serde_json::from_str(DEFAULT_POLICY).unwrap();
+        assert!(p.is_default_insecure());
+        for &v in &["{}", REASONABLY_LOCKED_DOWN] {
+            let p: ContainerPolicy = serde_json::from_str(v).unwrap();
+            assert!(!p.is_default_insecure());
+        }
+    }
 }


### PR DESCRIPTION
lib/container: Introduce OstreeImageReference with SignatureSource

I'm trying to put my foot down and say that *by default* booting
and updating an operating system should require a cryptographic
signature from the vendor as implemented by e.g. ostree (GPG or
"signapi" which can do simple ed25519+libsodium signatures).

Other signature mechanisms are possible and the containers/image
ecosystem supports signatures, but they are not widely deployed.

In order to implement ostree-based GPG/signapi verification, we
need the configuration for an ostree remote.  Hence, we support
`ostree-remote-image:$remotename:$containerref`.  For example,
`ostree-remote-image:fedora:registry:quay.io/coreos/fedora-coreos:stable`.

Having a canonical stringified representation of this will
allow using it on command lines and in user interfaces.  For example:

```
$ ostree remote add fedora --set=gpgkeypath=/etc/pki/rpm-gpg --custom-backend=ostree-ext
$ ostree-ext-cli rebase ostree-remote-image:fedora:quay.io/coreos/fedora-coreos:stable
```

(`ostree-ext-cli rebase` doesn't exist, but maybe it will later)

In addition, a signature policy of `ostree-image-signed` expresses
that we won't do signature verification via ostree, but we *will*
try to ensure that the containers/image (skopeo) path uses some
signature mechanism.

Finally we offer `ostree-unverified-image` to just boot a container
without caring about signatures.

---

container: Add support for `ostree-remote-registry`

This is a convenient shorthand for the very common case of fetching
from a registry (i.e. `docker://`).

---

