### PR TITLE
Misc

### DIFF
--- a/lib/src/container/import.rs
+++ b/lib/src/container/import.rs
@@ -1,5 +1,33 @@
 //! APIs for extracting OSTree commits from container images
 
+// # Implementation
+//
+// This code currently forks off `/usr/bin/skopeo` as a subprocess, and uses
+// it to fetch the container content and convert it into a `docker-archive:`
+// formatted tarball stream, which is written to a FIFO and parsed by
+// this code.
+//
+// The rationale for this is that `/usr/bin/skopeo` is a frontend for
+// the Go library https://github.com/containers/image/ which supports
+// key things we want for production use like:
+//
+// - Image mirroring and remapping; effectively `man containers-registries.conf`
+//   For example, we need to support an administrator mirroring an ostree-container
+//   into a disconnected registry, without changing all the pull specs.
+// - Signing
+//
+// # Import phases
+//
+// First, we support explicitly fetching just the manifest: https://github.com/opencontainers/image-spec/blob/main/manifest.md
+// This will give us information about the layers it contains, and crucially the digest (sha256) of
+// the manifest is how higher level software can detect changes.
+//
+// Once we have the manifest, we expect it to point to a single `application/vnd.oci.image.layer.v1.tar+gzip` layer,
+// which is exactly what is exported by the [`crate::tar::export`] process.
+//
+// What we get from skopeo is a `docker-archive:` tarball, which then will contain this *inner* tarball
+// layer that we extract and pass to the [`crate::tar::import`] code.
+
 use super::*;
 use anyhow::{anyhow, Context};
 use camino::Utf8Path;

--- a/lib/src/container/import.rs
+++ b/lib/src/container/import.rs
@@ -123,7 +123,7 @@ pub async fn find_layer_tar(
     Ok((reader, worker))
 }
 
-// Helper function invoked to synchronously parse a tar stream, finding
+// Helper function invoked to synchronously parse a `docker-archive:` formatted tar stream, finding
 // the desired layer tarball and writing its contents via a stream of byte chunks
 // to a channel.
 fn find_layer_tar_sync(

--- a/lib/src/container/import.rs
+++ b/lib/src/container/import.rs
@@ -66,13 +66,6 @@ pub async fn fetch_manifest_info(
     imgref: &OstreeImageReference,
 ) -> Result<OstreeContainerManifestInfo> {
     let (_, manifest_digest) = fetch_manifest(imgref).await?;
-    // Sadly this seems to be lost when pushing to e.g. quay.io, which means we can't use it.
-    //    let commit = manifest
-    //        .annotations
-    //        .as_ref()
-    //        .map(|a| a.get(OSTREE_COMMIT_LABEL))
-    //        .flatten()
-    //        .ok_or_else(|| anyhow!("Missing annotation {}", OSTREE_COMMIT_LABEL))?;
     Ok(OstreeContainerManifestInfo { manifest_digest })
 }
 

--- a/lib/src/container/import.rs
+++ b/lib/src/container/import.rs
@@ -141,20 +141,15 @@ fn find_layer_tar_sync(
             continue;
         }
         let path = entry.path()?;
-        let path = &*path;
-        let path =
-            Utf8Path::from_path(path).ok_or_else(|| anyhow!("Invalid non-utf8 path {:?}", path))?;
-        let t = entry.header().entry_type();
-
+        let path: &Utf8Path = path.deref().try_into()?;
         // We generally expect our layer to be first, but let's just skip anything
         // unexpected to be robust against changes in skopeo.
         if path.extension() != Some("tar") {
             continue;
         }
-
         event!(Level::DEBUG, "Found {}", path);
 
-        match t {
+        match entry.header().entry_type() {
             tar::EntryType::Symlink => {
                 if let Some(name) = path.file_name() {
                     if name == "layer.tar" {


### PR DESCRIPTION
lib/container/import: Drop commented code

Since it won't work in the near future and we don't need
it, just drop it.

---

lib/container/import: Minor code cleanup

Prep for future work.

---

lib/container/import: Add a clarifying comment

---

lib/container/import: Add some implementation docs

Was debating making this public module doc, but I think
documenting the implementation right now is most useful.

---

