### PR TITLE
Bump to 0.4, various container import API changes

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
-version = "0.3.1-alpha.0"
+version = "0.4.0-alpha.0"
 
 [dependencies]
 anyhow = "1.0"

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -193,12 +193,14 @@ async fn container_import(repo: &str, imgref: &str, write_ref: Option<&str>) -> 
             gio::NONE_CANCELLABLE,
         )?;
         println!(
-            "Imported: {} => {}",
-            write_ref,
-            import.ostree_commit.as_str()
+            "Imported: {} to ref {}",
+            import.digested_reference, write_ref
         );
     } else {
-        println!("Imported: {}", import.ostree_commit);
+        println!(
+            "Imported: {} (commit {})",
+            import.digested_reference, import.ostree_commit
+        );
     }
 
     Ok(())
@@ -226,8 +228,8 @@ async fn container_export(
 /// Load metadata for a container image with an encapsulated ostree commit.
 async fn container_info(imgref: &str) -> Result<()> {
     let imgref = imgref.try_into()?;
-    let info = crate::container::fetch_manifest_info(&imgref).await?;
-    println!("{} @{}", imgref, info.manifest_digest);
+    let digested = crate::container::fetch_manifest_info(&imgref).await?;
+    println!("{}", digested);
     Ok(())
 }
 

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -228,7 +228,7 @@ async fn container_export(
 /// Load metadata for a container image with an encapsulated ostree commit.
 async fn container_info(imgref: &str) -> Result<()> {
     let imgref = imgref.try_into()?;
-    let digested = crate::container::fetch_manifest_info(&imgref).await?;
+    let (_, digested) = crate::container::fetch_manifest(&imgref).await?;
     println!("{}", digested);
     Ok(())
 }

--- a/lib/src/container/export.rs
+++ b/lib/src/container/export.rs
@@ -129,7 +129,8 @@ async fn build_impl(
     // FIXME - it's obviously broken to do this push -> inspect cycle because of the possibility
     // of a race condition, but we need to patch skopeo to have the equivalent of `podman push --digestfile`.
     let info = super::import::fetch_manifest_info(&imgref).await?;
-    Ok(dest.with_digest(info.manifest_digest.as_str()))
+    // Safety: We know fetch_manifest_info returns a digested image
+    Ok(dest.with_digest(info.imgref.digest().unwrap()))
 }
 
 /// Given an OSTree repository and ref, generate a container image.

--- a/lib/src/container/export.rs
+++ b/lib/src/container/export.rs
@@ -128,9 +128,9 @@ async fn build_impl(
     };
     // FIXME - it's obviously broken to do this push -> inspect cycle because of the possibility
     // of a race condition, but we need to patch skopeo to have the equivalent of `podman push --digestfile`.
-    let info = super::import::fetch_manifest_info(&imgref).await?;
+    let (_, digested_imgref) = super::import::fetch_manifest(&imgref).await?;
     // Safety: We know fetch_manifest_info returns a digested image
-    Ok(dest.with_digest(info.imgref.digest().unwrap()))
+    Ok(dest.with_digest(digested_imgref.imgref.digest().unwrap()))
 }
 
 /// Given an OSTree repository and ref, generate a container image.

--- a/lib/src/container/import.rs
+++ b/lib/src/container/import.rs
@@ -90,11 +90,9 @@ impl AsyncRead for ProgressReader {
 
 /// Download the manifest for a target image.
 #[context("Fetching manifest")]
-pub async fn fetch_manifest_info(
-    imgref: &OstreeImageReference,
-) -> Result<OstreeContainerManifestInfo> {
+pub async fn fetch_manifest_info(imgref: &OstreeImageReference) -> Result<OstreeImageReference> {
     let (_, manifest_digest) = fetch_manifest(imgref).await?;
-    Ok(OstreeContainerManifestInfo { manifest_digest })
+    Ok(imgref.with_digest(&manifest_digest))
 }
 
 /// Download the manifest for a target image.
@@ -274,8 +272,8 @@ async fn fetch_layer<'s>(
 pub struct Import {
     /// The ostree commit that was imported
     pub ostree_commit: String,
-    /// The image digest retrieved
-    pub image_digest: String,
+    /// The image fetched including digest
+    pub digested_reference: OstreeImageReference,
 }
 
 fn find_layer_blobid(manifest: &oci::Manifest) -> Result<String> {
@@ -345,6 +343,6 @@ pub async fn import(
     event!(Level::DEBUG, "created commit {}", ostree_commit);
     Ok(Import {
         ostree_commit,
-        image_digest,
+        digested_reference: imgref.with_digest(&image_digest),
     })
 }

--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -116,6 +116,15 @@ impl ImageReference {
             name: format!("{}@{}", name, digest),
         }
     }
+
+    /// Return the @sha256:<checksum> portion of the image reference, if any.
+    pub fn digest(&self) -> Option<&str> {
+        if let Some(idx) = self.name.rfind('@') {
+            Some(self.name.split_at(idx).0)
+        } else {
+            None
+        }
+    }
 }
 
 impl OstreeImageReference {

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -276,7 +276,7 @@ async fn test_container_import_export() -> Result<()> {
     };
 
     let inspect = ostree_ext::container::fetch_manifest_info(&srcoci_unverified).await?;
-    assert_eq!(inspect.manifest_digest, digest);
+    assert_eq!(inspect.imgref.digest().unwrap(), digest);
 
     // No remote matching
     let srcoci_unknownremote = OstreeImageReference {

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -275,8 +275,8 @@ async fn test_container_import_export() -> Result<()> {
         imgref: srcoci_imgref.clone(),
     };
 
-    let inspect = ostree_ext::container::fetch_manifest_info(&srcoci_unverified).await?;
-    assert_eq!(inspect.imgref.digest().unwrap(), digest);
+    let (_, digested_imgref) = ostree_ext::container::fetch_manifest(&srcoci_unverified).await?;
+    assert_eq!(digested_imgref.imgref.digest().unwrap(), digest);
 
     // No remote matching
     let srcoci_unknownremote = OstreeImageReference {


### PR DESCRIPTION
lib: Bump to 0.4.0-alpha.0

I plan to make some API changes in the `container` module at least.

---

lib/container: Change API to use complete digested image references

Rather than having our manifest fetch API just return a `String`
that's a sha256 checksum, instead return a full `OstreeImageReference`
copy of the input image reference, just with a digest.

This helps ensure we're consistently using image references.

---

lib/container: Only have one manifest fetch path

It was confusing to have a codepath that returns just the
digest, and another that fetches the parsed data and the digest.

Instead, fetch *unparsed* data (so that we don't need to expose
`oci::Manifest` as public API) as well as the digested image.

Prep for avoiding an extra round trip in the import path
to fetch the manifest when the caller already has it, in case
they wanted to do change detection.

---

lib/container: Add an API that uses an already fetched manifest

The flow here is then nicer, because at a high level apps like
rpm-ostree will want to do:

- Fetch manifest, digest pair
- Do we already have this? If so, we're done
- Otherwise, perform the fetch using that already downloaded manifest

Previously we were fetching the manifest twice.

---

