### PR TITLE
lib: Bump to 0.4.0-alpha.0

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
-version = "0.3.1-alpha.0"
+version = "0.4.0-alpha.0"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
I plan to make some API changes in the `container` module at least.