### PR TITLE
lib/container: Remove with_digest() method

### DIFF
--- a/lib/src/container/export.rs
+++ b/lib/src/container/export.rs
@@ -89,7 +89,7 @@ async fn build_impl(
     ostree_ref: &str,
     config: &Config,
     dest: &ImageReference,
-) -> Result<ImageReference> {
+) -> Result<String> {
     let compression = if dest.transport == Transport::ContainerStorage {
         Some(flate2::Compression::none())
     } else {
@@ -129,7 +129,7 @@ async fn build_impl(
     // FIXME - it's obviously broken to do this push -> inspect cycle because of the possibility
     // of a race condition, but we need to patch skopeo to have the equivalent of `podman push --digestfile`.
     let info = super::import::fetch_manifest_info(&imgref).await?;
-    Ok(dest.with_digest(info.manifest_digest.as_str()))
+    Ok(info.manifest_digest)
 }
 
 /// Given an OSTree repository and ref, generate a container image.
@@ -140,6 +140,6 @@ pub async fn export<S: AsRef<str>>(
     ostree_ref: S,
     config: &Config,
     dest: &ImageReference,
-) -> Result<ImageReference> {
+) -> Result<String> {
     build_impl(repo, ostree_ref.as_ref(), config, dest).await
 }

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -259,11 +259,10 @@ async fn test_container_import_export() -> Result<()> {
         ),
         cmd: Some(vec!["/bin/bash".to_string()]),
     };
-    let pushed = ostree_ext::container::export(srcrepo, TESTREF, &config, &srcoci_imgref)
+    let digest = ostree_ext::container::export(srcrepo, TESTREF, &config, &srcoci_imgref)
         .await
         .context("exporting")?;
     assert!(srcoci_path.exists());
-    let digest = pushed.name.rsplitn(2, '@').next().unwrap();
 
     let inspect = skopeo_inspect(&srcoci_imgref.to_string())?;
     assert!(inspect.contains(r#""version": "42.0""#));


### PR DESCRIPTION
Per `man containers-transports`, transports like `oci-archive:`
don't support digests, and even major ones like `containers-storage:`
and `docker://` don't quite handle them in the same way.

For now, avoid trying to mutate transport references.  It's just
the push path that was doing this; instead just return the digest
as a string.  We will likely need to special case `docker://` but
that can come later.