### PR TITLE
lib/container: Explicitly drain stream

### DIFF
--- a/lib/src/container/import.rs
+++ b/lib/src/container/import.rs
@@ -118,36 +118,30 @@ async fn fetch_manifest(imgref: &OstreeImageReference) -> Result<(oci::Manifest,
 
 /// Read the contents of the first <checksum>.tar we find.
 /// The first return value is an `AsyncRead` of that tar file.
-/// The second return value is a background worker task that will
-/// return back to the caller the provided input stream (converted
-/// to a synchronous reader).  This ensures the caller can take
-/// care of closing the input stream.
+/// The second return value is a background worker task that
+/// owns stream processing.
 pub async fn find_layer_tar(
     src: impl AsyncRead + Send + Unpin + 'static,
     blobid: &str,
-) -> Result<(
-    impl AsyncRead,
-    impl Future<Output = Result<impl Read + Send + Unpin + 'static>>,
-)> {
+) -> Result<(impl AsyncRead, impl Future<Output = Result<Result<()>>>)> {
     // Convert the async input stream to synchronous, becuase we currently use the
     // sync tar crate.
     let pipein = crate::async_util::async_read_to_sync(src);
     // An internal channel of Bytes
     let (tx_buf, rx_buf) = tokio::sync::mpsc::channel(2);
     let blob_symlink_target = format!("../{}.tar", blobid);
-    let import = tokio::task::spawn_blocking(move || {
-        find_layer_tar_sync(pipein, blob_symlink_target, tx_buf)
+    let worker = tokio::task::spawn_blocking(move || {
+        let mut pipein = pipein;
+        let r =
+            find_layer_tar_sync(&mut pipein, blob_symlink_target, tx_buf).context("Import worker");
+        // Ensure we read the entirety of the stream, otherwise skopeo will get an EPIPE.
+        let _ = std::io::copy(&mut pipein, &mut std::io::sink());
+        r
     })
     .map_err(anyhow::Error::msg);
     // Bridge the channel to an AsyncRead
     let stream = tokio_stream::wrappers::ReceiverStream::new(rx_buf);
     let reader = tokio_util::io::StreamReader::new(stream);
-    // This async task owns the internal worker thread, which also owns the provided
-    // input stream which we return to the caller.
-    let worker = async move {
-        let src_as_sync = import.await?.context("Import worker")?;
-        Ok::<_, anyhow::Error>(src_as_sync)
-    };
     Ok((reader, worker))
 }
 
@@ -158,7 +152,7 @@ fn find_layer_tar_sync(
     pipein: impl Read + Send + Unpin,
     blob_symlink_target: String,
     tx_buf: tokio::sync::mpsc::Sender<std::io::Result<bytes::Bytes>>,
-) -> Result<impl Read + Send + Unpin> {
+) -> Result<()> {
     let mut archive = tar::Archive::new(pipein);
     let mut buf = vec![0u8; 8192];
     let mut found = false;
@@ -212,7 +206,7 @@ fn find_layer_tar_sync(
         }
     }
     if found {
-        Ok(archive.into_inner())
+        Ok(())
     } else {
         Err(anyhow!("Failed to find layer {}", blob_symlink_target))
     }
@@ -260,10 +254,12 @@ async fn fetch_layer<'s>(
     }
     .boxed();
     let (contents, worker) = find_layer_tar(fifo_reader, blobid).await?;
+    // This worker task joins the result of the stream processing thread with monitoring the skopeo process.
     let worker = async move {
         let (worker, waiter) = tokio::join!(worker, waiter);
+        // Explicitly declare as `()` to verify we have the right number of `?`.
         let _: () = waiter?;
-        let _pipein = worker.context("Layer worker failed")?;
+        let _: () = worker??;
         Ok::<_, anyhow::Error>(())
     };
     Ok((contents, worker))


### PR DESCRIPTION
Rather than passing the FIFO stream ownership into and back out
of the parser, just pass an `&mut` reference, and then
explicitly drain it in the worker thread.

This motivates then cleaning up our "worker" futures.  Add some
comments too.

Prep for future work.

---

