### PR TITLE
lib/tar: Add new `write` module

### DIFF
--- a/lib/src/cmdext.rs
+++ b/lib/src/cmdext.rs
@@ -1,0 +1,21 @@
+use std::os::unix::prelude::{CommandExt, RawFd};
+
+pub(crate) trait CommandRedirectionExt {
+    /// Pass a file descriptor into the target process.
+    /// IMPORTANT: `fd` must be valid (i.e. cannot be closed) until after [`std::Process::Command::spawn`] or equivalent is invoked.
+    fn take_fd_n(&mut self, fd: i32, target: i32) -> &mut Self;
+}
+
+#[allow(unsafe_code)]
+impl CommandRedirectionExt for std::process::Command {
+    fn take_fd_n(&mut self, fd: i32, target: i32) -> &mut Self {
+        unsafe {
+            self.pre_exec(move || {
+                nix::unistd::dup2(fd, target as RawFd)
+                    .map(|_r| ())
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("{}", e)))
+            });
+        }
+        self
+    }
+}

--- a/lib/src/ima.rs
+++ b/lib/src/ima.rs
@@ -49,7 +49,7 @@ fn xattrs_to_map(v: &glib::Variant) -> BTreeMap<Vec<u8>, Vec<u8>> {
 }
 
 /// Create a new GVariant of type a(ayay).  This is used by OSTree's extended attributes.
-fn new_variant_a_ayay<'a, T: 'a + AsRef<[u8]>>(
+pub(crate) fn new_variant_a_ayay<'a, T: 'a + AsRef<[u8]>>(
     items: impl IntoIterator<Item = (T, T)>,
 ) -> glib::Variant {
     let children: Vec<_> = items

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -27,6 +27,9 @@ pub mod container;
 pub mod diff;
 pub mod ima;
 pub mod tar;
+
+mod cmdext;
+
 /// Prelude, intended for glob import.
 pub mod prelude {
     #[doc(hidden)]

--- a/lib/src/tar/import.rs
+++ b/lib/src/tar/import.rs
@@ -24,7 +24,7 @@ const MAX_XATTR_SIZE: u32 = 1024 * 1024;
 const MAX_METADATA_SIZE: u32 = 10 * 1024 * 1024;
 
 /// https://stackoverflow.com/questions/258091/when-should-i-use-mmap-for-file-access
-const SMALL_REGFILE_SIZE: usize = 127 * 1024;
+pub(crate) const SMALL_REGFILE_SIZE: usize = 127 * 1024;
 
 // The prefix for filenames that contain content we actually look at.
 const REPO_PREFIX: &str = "sysroot/ostree/repo/";

--- a/lib/src/tar/mod.rs
+++ b/lib/src/tar/mod.rs
@@ -41,3 +41,5 @@ mod import;
 pub use import::*;
 mod export;
 pub use export::*;
+mod write;
+pub use write::*;

--- a/lib/src/tar/write.rs
+++ b/lib/src/tar/write.rs
@@ -1,0 +1,98 @@
+//! APIs to write a tarball stream into an OSTree commit.
+//!
+//! This functionality already exists in libostree mostly,
+//! this API adds a higher level, more ergonomic Rust frontend
+//! to it.
+//!
+//! In the future, this may also evolve into parsing the tar
+//! stream in Rust, not in C.
+
+use crate::cmdext::CommandRedirectionExt;
+use crate::Result;
+use anyhow::anyhow;
+use std::os::unix::prelude::AsRawFd;
+use tokio::io::AsyncReadExt;
+use tracing::instrument;
+
+/// Configuration for tar layer commits.
+#[derive(Debug, Default)]
+pub struct WriteTarOptions<'a> {
+    /// Base ostree commit hash
+    pub base: Option<&'a str>,
+    /// Enable SELinux labeling from the base commit
+    /// Requires the `base` option.
+    pub selinux: bool,
+}
+
+/// Write the contents of a tarball as an ostree commit.
+#[allow(unsafe_code)] // For raw fd bits
+#[instrument(skip(repo, src))]
+pub async fn write_tar(
+    repo: &ostree::Repo,
+    mut src: impl tokio::io::AsyncRead + Send + Unpin + 'static,
+    refname: &str,
+    options: Option<WriteTarOptions<'_>>,
+) -> Result<String> {
+    use std::process::Stdio;
+    let options = options.unwrap_or_default();
+    let mut c = std::process::Command::new("ostree");
+    let repofd = repo.dfd_as_file()?;
+    {
+        let c = c
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .args(&["commit"]);
+        c.take_fd_n(repofd.as_raw_fd(), 3);
+        c.arg("--repo=/proc/self/fd/3");
+        if let Some(base) = options.base {
+            if options.selinux {
+                c.arg("--selinux-policy-from-base");
+            }
+            c.arg(&format!("--tree=ref={}", base));
+        }
+        c.args(&[
+            "--no-bindings",
+            "--tar-autocreate-parents",
+            "--tree=tar=/proc/self/fd/0",
+            "--branch",
+            refname,
+        ]);
+    }
+    let mut c = tokio::process::Command::from(c);
+    c.kill_on_drop(true);
+    let mut r = c.spawn()?;
+    // Safety: We passed piped() for all of these
+    let mut child_stdin = r.stdin.take().unwrap();
+    let mut child_stdout = r.stdout.take().unwrap();
+    let mut child_stderr = r.stderr.take().unwrap();
+    // Copy our input to child stdout
+    let input_copier = async move {
+        let _n = tokio::io::copy(&mut src, &mut child_stdin).await?;
+        drop(child_stdin);
+        Ok::<_, anyhow::Error>(())
+    };
+    // Gather stdout/stderr to buffers
+    let output_copier = async move {
+        let mut child_stdout_buf = String::new();
+        let mut child_stderr_buf = String::new();
+        let (_a, _b) = tokio::try_join!(
+            child_stdout.read_to_string(&mut child_stdout_buf),
+            child_stderr.read_to_string(&mut child_stderr_buf)
+        )?;
+        Ok::<_, anyhow::Error>((child_stdout_buf, child_stderr_buf))
+    };
+
+    let (_, (child_stdout, child_stderr)) = tokio::try_join!(input_copier, output_copier)?;
+    let status = r.wait().await?;
+    if !status.success() {
+        return Err(anyhow!(
+            "Failed to commit tar: {:?}: {}",
+            status,
+            child_stderr
+        ));
+    }
+    // TODO: trim string in place
+    let s = child_stdout.trim();
+    Ok(s.to_string())
+}

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -250,6 +250,20 @@ async fn test_tar_import_export() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn test_tar_write() -> Result<()> {
+    let fixture = Fixture::new()?;
+    let r = ostree_ext::tar::write_tar(&fixture.destrepo, EXAMPLEOS_V0, "exampleos", None).await?;
+    let (commitdata, _) = fixture.destrepo.load_commit(&r)?;
+    assert_eq!(
+        EXAMPLEOS_CONTENT_CHECKSUM,
+        ostree::commit_get_content_checksum(&commitdata)
+            .unwrap()
+            .as_str()
+    );
+    Ok(())
+}
+
 fn skopeo_inspect(imgref: &str) -> Result<String> {
     let out = Command::new("skopeo")
         .args(&["inspect", imgref])


### PR DESCRIPTION
APIs to write a tarball stream into an OSTree commit.

This functionality already exists in libostree mostly,
this API adds a higher level, more ergonomic Rust frontend
to it.

In the future, this may also evolve into parsing the tar
stream in Rust, not in C.

Prep for container derivation.