### PR TITLE
Fetch via container-image-proxy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,11 +19,9 @@ jobs:
     container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
 
     steps:
-    - name: Install skopeo
-      run: yum -y install skopeo
-    - name: Update ostree
-      run: yum -y --enablerepo=updates-testing update ostree-devel
     - uses: actions/checkout@v2
+    - name: Install deps
+      run: ./ci/installdeps.sh
     - name: Format
       run: cargo fmt -- --check -l
     - name: Build

--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -xeuo pipefail
+
+yum -y install skopeo
+yum -y --enablerepo=updates-testing update ostree-devel
+
+git clone --depth=1 https://github.com/cgwalters/container-image-proxy
+cd container-image-proxy
+make
+install -m 0755 bin/container-image-proxy /usr/bin/

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.4.0-alpha.0"
 
 [dependencies]
 anyhow = "1.0"
+async-compression = { version = "0.3", features = ["gzip", "tokio"] }
 bytes = "1.0.1"
 bitflags = "1.3.2"
 camino = "1.0.4"
@@ -19,6 +20,7 @@ fn-error-context = "0.2.0"
 futures-util = "0.3.13"
 gvariant = "0.4.0"
 hex = "0.4.3"
+hyper = { version = "0.14", features = ["full"] }
 indicatif = "0.16.0"
 lazy_static = "1.4.0"
 libc = "0.2.92"

--- a/lib/src/container/imageproxy.rs
+++ b/lib/src/container/imageproxy.rs
@@ -1,0 +1,139 @@
+//! Run container-image-proxy as a subprocess.
+//! This allows fetching a container image manifest and layers in a streaming fashioni.
+
+use super::{ImageReference, Result};
+use crate::cmdext::CommandRedirectionExt;
+use anyhow::Context;
+use futures_util::{Future, FutureExt, TryFutureExt, TryStreamExt};
+use hyper::body::HttpBody;
+use hyper::client::conn::{Builder, SendRequest};
+use hyper::{Body, Request, StatusCode};
+use std::os::unix::prelude::AsRawFd;
+use std::pin::Pin;
+use std::process::Stdio;
+use tokio::io::{AsyncBufRead, AsyncReadExt};
+
+// What we get from boxing a fallible tokio::spawn() closure.  Note the nested Result.
+type JoinFuture<T> = Pin<Box<dyn Future<Output = Result<Result<T>>>>>;
+
+/// Manage a child process proxy to fetch container images.
+pub(crate) struct ImageProxy {
+    proc: tokio::process::Child,
+    request_sender: SendRequest<Body>,
+    stderr: JoinFuture<String>,
+    driver: JoinFuture<()>,
+}
+
+impl ImageProxy {
+    pub(crate) async fn new(imgref: &ImageReference) -> Result<Self> {
+        // Communicate over an anonymous socketpair(2)
+        let (mysock, childsock) = tokio::net::UnixStream::pair()?;
+        let childsock = childsock.into_std()?;
+        let mut c = std::process::Command::new("container-image-proxy");
+        c.arg(&imgref.to_string());
+        c.stdout(Stdio::null()).stderr(Stdio::piped());
+        if let Some(port) = std::env::var_os("OSTREE_IMAGE_PROXY_PORT") {
+            c.arg("--port");
+            c.arg(port);
+        } else {
+            // Pass one half of the pair as fd 3 to the child
+            let target_fd = 3;
+            c.arg("--sockfd");
+            c.arg(&format!("{}", target_fd));
+            c.take_fd_n(childsock.as_raw_fd(), target_fd);
+        }
+        let mut c = tokio::process::Command::from(c);
+        c.kill_on_drop(true);
+        let mut proc = c.spawn()?;
+        // We've passed over the fd, close it.
+        drop(childsock);
+
+        // Safety: We passed `Stdio::piped()` above
+        let mut child_stderr = proc.stderr.take().unwrap();
+
+        // Connect via HTTP to the child
+        let (request_sender, connection) = Builder::new().handshake::<_, Body>(mysock).await?;
+        // Background driver that manages things like timeouts.
+        let driver = tokio::spawn(connection.map_err(anyhow::Error::msg))
+            .map_err(anyhow::Error::msg)
+            .boxed();
+        let stderr = tokio::spawn(async move {
+            let mut buf = String::new();
+            child_stderr.read_to_string(&mut buf).await?;
+            Ok(buf)
+        })
+        .map_err(anyhow::Error::msg)
+        .boxed();
+        Ok(Self {
+            proc,
+            stderr,
+            request_sender,
+            driver,
+        })
+    }
+
+    pub(crate) async fn fetch_manifest(&mut self) -> Result<(String, Vec<u8>)> {
+        let req = Request::builder()
+            .header("Host", "localhost")
+            .method("GET")
+            .uri("/manifest")
+            .body(Body::from(""))?;
+        let mut resp = self.request_sender.send_request(req).await?;
+        if resp.status() != StatusCode::OK {
+            return Err(anyhow::anyhow!("error from proxy: {}", resp.status()));
+        }
+        let hname = "Manifest-Digest";
+        let digest = resp
+            .headers()
+            .get(hname)
+            .ok_or_else(|| anyhow::anyhow!("Missing {} header", hname))?
+            .to_str()
+            .with_context(|| format!("Invalid {} header", hname))?
+            .to_string();
+        let mut ret = Vec::new();
+        while let Some(chunk) = resp.body_mut().data().await {
+            let chunk = chunk?;
+            ret.extend_from_slice(&chunk);
+        }
+        Ok((digest, ret))
+    }
+
+    pub(crate) async fn fetch_blob(
+        &mut self,
+        digest: &str,
+    ) -> Result<impl AsyncBufRead + Send + Unpin> {
+        let uri = format!("/blobs/{}", digest);
+        let req = Request::builder()
+            .header("Host", "localhost")
+            .method("GET")
+            .uri(&uri)
+            .body(Body::from(""))?;
+        let resp = self.request_sender.send_request(req).await?;
+        let status = resp.status();
+        let body = TryStreamExt::map_err(resp.into_body(), |e| {
+            std::io::Error::new(std::io::ErrorKind::Other, e)
+        });
+        let mut body = tokio_util::io::StreamReader::new(body);
+        if status != StatusCode::OK {
+            let mut s = String::new();
+            let _: usize = body.read_to_string(&mut s).await?;
+            return Err(anyhow::anyhow!("error from proxy: {}: {}", status, s));
+        }
+        Ok(body)
+    }
+
+    pub(crate) async fn finalize(mut self) -> Result<()> {
+        // For now discard any errors from the connection
+        drop(self.request_sender);
+        let _r = self.driver.await??;
+        let status = self.proc.wait().await?;
+        if !status.success() {
+            if let Some(stderr) = self.stderr.await.map(|v| v.ok()).ok().flatten() {
+                anyhow::bail!("proxy failed: {}\n{}", status, stderr)
+            } else {
+                anyhow::bail!("proxy failed: {} (failed to fetch stderr)", status)
+            }
+        }
+        Ok(())
+    }
+}

--- a/lib/src/container/import.rs
+++ b/lib/src/container/import.rs
@@ -1,22 +1,25 @@
 //! APIs for extracting OSTree commits from container images
+//!
+//! # External depenendency on container-image-proxy
+//!
+//! This code requires https://github.com/cgwalters/container-image-proxy
+//! installed as a binary in $PATH.
+//!
+//! The rationale for this is that while there exist Rust crates to speak
+//! the Docker distribution API, the Go library https://github.com/containers/image/
+//! supports key things we want for production use like:
+//!
+//! - Image mirroring and remapping; effectively `man containers-registries.conf`
+//!   For example, we need to support an administrator mirroring an ostree-container
+//!   into a disconnected registry, without changing all the pull specs.
+//! - Signing
+//!
+//! Additionally, the proxy "upconverts" manifests into OCI, so we don't need to care
+//! about parsing the Docker manifest format (as used by most registries still).
+//!
+//!
 
 // # Implementation
-//
-// This code currently forks off `/usr/bin/skopeo` as a subprocess, and uses
-// it to fetch the container content and convert it into a `docker-archive:`
-// formatted tarball stream, which is written to a FIFO and parsed by
-// this code.
-//
-// The rationale for this is that `/usr/bin/skopeo` is a frontend for
-// the Go library https://github.com/containers/image/ which supports
-// key things we want for production use like:
-//
-// - Image mirroring and remapping; effectively `man containers-registries.conf`
-//   For example, we need to support an administrator mirroring an ostree-container
-//   into a disconnected registry, without changing all the pull specs.
-// - Signing
-//
-// # Import phases
 //
 // First, we support explicitly fetching just the manifest: https://github.com/opencontainers/image-spec/blob/main/manifest.md
 // This will give us information about the layers it contains, and crucially the digest (sha256) of
@@ -24,18 +27,11 @@
 //
 // Once we have the manifest, we expect it to point to a single `application/vnd.oci.image.layer.v1.tar+gzip` layer,
 // which is exactly what is exported by the [`crate::tar::export`] process.
-//
-// What we get from skopeo is a `docker-archive:` tarball, which then will contain this *inner* tarball
-// layer that we extract and pass to the [`crate::tar::import`] code.
 
 use super::*;
 use anyhow::{anyhow, Context};
-use camino::Utf8Path;
 use fn_error_context::context;
-use futures_util::{Future, FutureExt, TryFutureExt};
-use std::io::prelude::*;
 use std::pin::Pin;
-use std::process::Stdio;
 use tokio::io::AsyncRead;
 use tracing::{event, instrument, Level};
 
@@ -91,172 +87,9 @@ impl AsyncRead for ProgressReader {
 /// Download the manifest for a target image and its sha256 digest.
 #[context("Fetching manifest")]
 pub async fn fetch_manifest(imgref: &OstreeImageReference) -> Result<(Vec<u8>, String)> {
-    let mut proc = skopeo::new_cmd();
-    let imgref_base = &imgref.imgref;
-    proc.args(&["inspect", "--raw"])
-        .arg(imgref_base.to_string());
-    proc.stdout(Stdio::piped());
-    let proc = skopeo::spawn(proc)?.wait_with_output().await?;
-    if !proc.status.success() {
-        let errbuf = String::from_utf8_lossy(&proc.stderr);
-        return Err(anyhow!("skopeo inspect failed\n{}", errbuf));
-    }
-    let raw_manifest = proc.stdout;
-    let digest = openssl::hash::hash(openssl::hash::MessageDigest::sha256(), &raw_manifest)?;
-    let digest = format!("sha256:{}", hex::encode(digest.as_ref()));
+    let mut proxy = imageproxy::ImageProxy::new(&imgref.imgref).await?;
+    let (digest, raw_manifest) = proxy.fetch_manifest().await?;
     Ok((raw_manifest, digest))
-}
-
-/// Read the contents of the first <checksum>.tar we find.
-/// The first return value is an `AsyncRead` of that tar file.
-/// The second return value is a background worker task that
-/// owns stream processing.
-pub async fn find_layer_tar(
-    src: impl AsyncRead + Send + Unpin + 'static,
-    blobid: &str,
-) -> Result<(impl AsyncRead, impl Future<Output = Result<Result<()>>>)> {
-    // Convert the async input stream to synchronous, becuase we currently use the
-    // sync tar crate.
-    let pipein = crate::async_util::async_read_to_sync(src);
-    // An internal channel of Bytes
-    let (tx_buf, rx_buf) = tokio::sync::mpsc::channel(2);
-    let blob_sha256 = blobid
-        .strip_prefix("sha256:")
-        .ok_or_else(|| anyhow!("Expected sha256: in digest: {}", blobid))?;
-    let blob_symlink_target = format!("../{}.tar", blob_sha256);
-    let worker = tokio::task::spawn_blocking(move || {
-        let mut pipein = pipein;
-        let r =
-            find_layer_tar_sync(&mut pipein, blob_symlink_target, tx_buf).context("Import worker");
-        // Ensure we read the entirety of the stream, otherwise skopeo will get an EPIPE.
-        let _ = std::io::copy(&mut pipein, &mut std::io::sink());
-        r
-    })
-    .map_err(anyhow::Error::msg);
-    // Bridge the channel to an AsyncRead
-    let stream = tokio_stream::wrappers::ReceiverStream::new(rx_buf);
-    let reader = tokio_util::io::StreamReader::new(stream);
-    Ok((reader, worker))
-}
-
-// Helper function invoked to synchronously parse a `docker-archive:` formatted tar stream, finding
-// the desired layer tarball and writing its contents via a stream of byte chunks
-// to a channel.
-fn find_layer_tar_sync(
-    pipein: impl Read + Send + Unpin,
-    blob_symlink_target: String,
-    tx_buf: tokio::sync::mpsc::Sender<std::io::Result<bytes::Bytes>>,
-) -> Result<()> {
-    let mut archive = tar::Archive::new(pipein);
-    let mut buf = vec![0u8; 8192];
-    let mut found = false;
-    for entry in archive.entries()? {
-        let mut entry = entry.context("Reading entry")?;
-        if found {
-            // Continue to read to the end to avoid broken pipe error from skopeo
-            continue;
-        }
-        let path = entry.path()?;
-        let path: &Utf8Path = path.deref().try_into()?;
-        // We generally expect our layer to be first, but let's just skip anything
-        // unexpected to be robust against changes in skopeo.
-        if path.extension() != Some("tar") {
-            continue;
-        }
-        event!(Level::DEBUG, "Found {}", path);
-
-        match entry.header().entry_type() {
-            tar::EntryType::Symlink => {
-                if let Some(name) = path.file_name() {
-                    if name == "layer.tar" {
-                        let target = entry
-                            .link_name()?
-                            .ok_or_else(|| anyhow!("Invalid link {}", path))?;
-                        let target = Utf8Path::from_path(&*target)
-                            .ok_or_else(|| anyhow!("Invalid non-UTF8 path {:?}", target))?;
-                        if target != blob_symlink_target {
-                            return Err(anyhow!(
-                                "Found unexpected layer link {} -> {}",
-                                path,
-                                target
-                            ));
-                        }
-                    }
-                }
-            }
-            tar::EntryType::Regular => loop {
-                let n = entry
-                    .read(&mut buf[..])
-                    .context("Reading tar file contents")?;
-                let done = 0 == n;
-                let r = Ok::<_, std::io::Error>(bytes::Bytes::copy_from_slice(&buf[0..n]));
-                let receiver_closed = tx_buf.blocking_send(r).is_err();
-                if receiver_closed || done {
-                    found = true;
-                    break;
-                }
-            },
-            _ => continue,
-        }
-    }
-    if found {
-        Ok(())
-    } else {
-        Err(anyhow!("Failed to find layer {}", blob_symlink_target))
-    }
-}
-
-/// Fetch a remote docker/OCI image and extract a specific uncompressed layer.
-async fn fetch_layer<'s>(
-    imgref: &OstreeImageReference,
-    blobid: &str,
-    progress: Option<tokio::sync::watch::Sender<ImportProgress>>,
-) -> Result<(
-    impl AsyncRead + Unpin + Send,
-    impl Future<Output = Result<()>>,
-)> {
-    let mut proc = skopeo::new_cmd();
-    proc.stdout(Stdio::null());
-    let tempdir = tempfile::Builder::new()
-        .prefix("ostree-rs-ext")
-        .tempdir_in("/var/tmp")?;
-    let tempdir = Utf8Path::from_path(tempdir.path()).unwrap();
-    let fifo = &tempdir.join("skopeo.pipe");
-    nix::unistd::mkfifo(
-        fifo.as_os_str(),
-        nix::sys::stat::Mode::from_bits(0o600).unwrap(),
-    )?;
-    tracing::trace!("skopeo pull starting to {}", fifo);
-    proc.arg("copy")
-        .arg(imgref.imgref.to_string())
-        .arg(format!("docker-archive:{}", fifo));
-    let proc = skopeo::spawn(proc)?;
-    let fifo_reader = ProgressReader {
-        reader: Box::new(tokio::fs::File::open(fifo).await?),
-        progress,
-    };
-    let waiter = async move {
-        let res = proc.wait_with_output().await?;
-        if !res.status.success() {
-            return Err(anyhow!(
-                "skopeo failed: {}\n{}",
-                res.status,
-                String::from_utf8_lossy(&res.stderr)
-            ));
-        }
-        Ok(())
-    }
-    .boxed();
-    let (contents, worker) = find_layer_tar(fifo_reader, blobid).await?;
-    // This worker task joins the result of the stream processing thread with monitoring the skopeo process.
-    let worker = async move {
-        let (worker, waiter) = tokio::join!(worker, waiter);
-        // Explicitly declare as `()` to verify we have the right number of `?`.
-        let _: () = waiter?;
-        let _: () = worker??;
-        Ok::<_, anyhow::Error>(())
-    };
-    Ok((contents, worker))
 }
 
 /// The result of an import operation
@@ -324,19 +157,23 @@ pub async fn import_from_manifest(
     let manifest: oci::Manifest = serde_json::from_slice(manifest_bytes)?;
     let layerid = require_one_layer_blob(&manifest)?;
     event!(Level::DEBUG, "target blob: {}", layerid);
-    let (blob, worker) = fetch_layer(imgref, layerid, options.progress).await?;
-    let blob = tokio::io::BufReader::new(blob);
+    let mut proxy = imageproxy::ImageProxy::new(&imgref.imgref).await?;
+    let blob = proxy.fetch_blob(layerid).await?;
+    let blob = async_compression::tokio::bufread::GzipDecoder::new(blob);
+    let blob = ProgressReader {
+        reader: Box::new(blob),
+        progress: options.progress,
+    };
     let mut taropts: crate::tar::TarImportOptions = Default::default();
     match &imgref.sigverify {
         SignatureSource::OstreeRemote(remote) => taropts.remote = Some(remote.clone()),
         SignatureSource::ContainerPolicy | SignatureSource::ContainerPolicyAllowInsecure => {}
     }
-    let import = crate::tar::import_tar(repo, blob, Some(taropts));
-    let (ostree_commit, worker) = tokio::join!(import, worker);
-    // Let any errors from skopeo take precedence, because a failure to parse/find the layer tarball
-    // is likely due to an underlying error from that.
-    let _: () = worker?;
-    let ostree_commit = ostree_commit?;
+    let ostree_commit = crate::tar::import_tar(repo, blob, Some(taropts))
+        .await
+        .with_context(|| format!("Parsing blob {}", layerid))?;
+    // FIXME write ostree commit after proxy finalization
+    proxy.finalize().await?;
     event!(Level::DEBUG, "created commit {}", ostree_commit);
     Ok(ostree_commit)
 }

--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -227,6 +227,7 @@ mod export;
 pub use export::*;
 mod import;
 pub use import::*;
+mod imageproxy;
 mod oci;
 mod skopeo;
 

--- a/lib/src/container/skopeo.rs
+++ b/lib/src/container/skopeo.rs
@@ -1,7 +1,6 @@
 //! Fork skopeo as a subprocess
 
-use super::Result;
-use anyhow::Context;
+use anyhow::{Context, Result};
 use serde::Deserialize;
 use std::process::Stdio;
 use tokio::process::Command;


### PR DESCRIPTION

https://github.com/cgwalters/container-image-proxy
is prototype code to expose containers/image via a HTTP API
suitable for use in non-Go programs.

This has many advantages over us forking skopeo; the key one being
on-demand layer fetching.


Closes: https://github.com/ostreedev/ostree-rs-ext/issues/18
