### PR TITLE
Layered import followups

### DIFF
--- a/lib/src/container/imageproxy.rs
+++ b/lib/src/container/imageproxy.rs
@@ -44,7 +44,7 @@ impl ImageProxy {
         }
         let mut c = tokio::process::Command::from(c);
         c.kill_on_drop(true);
-        let mut proc = c.spawn()?;
+        let mut proc = c.spawn().context("Failed to spawn container-image-proxy")?;
         // We've passed over the fd, close it.
         drop(childsock);
 


### PR DESCRIPTION
imageproxy: Add context to failure to spawn

Since missing the binary is probably going to be common.

---

imageproxy: Add some docstrings

On general principle.

---

