### PR TITLE
lib/container: Use pin-project for ProgressReader

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -31,6 +31,7 @@ openat-ext = "0.2.0"
 openssl = "0.10.33"
 ostree = { features = ["v2021_4"], version = "0.13.0" }
 phf = { features = ["macros"], version = "0.9.0" }
+pin-project = "1.0"
 serde = { features = ["derive"], version = "1.0.125" }
 serde_json = "1.0.64"
 structopt = "0.3.21"

--- a/lib/src/tar/import.rs
+++ b/lib/src/tar/import.rs
@@ -1,5 +1,6 @@
 //! APIs for extracting OSTree commits from container images
 
+use crate::async_util::ReadBridge;
 use crate::Result;
 use anyhow::{anyhow, Context};
 use camino::Utf8Path;
@@ -603,10 +604,10 @@ pub async fn import_tar(
     options: Option<TarImportOptions>,
 ) -> Result<String> {
     let options = options.unwrap_or_default();
-    let pipein = crate::async_util::async_read_to_sync(src);
+    let src = ReadBridge::new(src);
     let repo = repo.clone();
     let import = tokio::task::spawn_blocking(move || {
-        let mut archive = tar::Archive::new(pipein);
+        let mut archive = tar::Archive::new(src);
         let importer = Importer::new(&repo, options.remote);
         importer.import(&mut archive)
     })


### PR DESCRIPTION
lib/container: Use pin-project for ProgressReader

I recently read through https://fasterthanli.me/articles/pin-and-suffering
and realized the use of pin-project is what we need here.

This avoids us need an `Unpin` bound which is nicer.

I also switched to avoid mutating our own structure (if progress
receiver disconnects we just keep trying to send) because I was
fighting `Pin` + mutability.

---

lib: Clean up AsyncRead → Read bridge

I have now realized why so many APIs in std and tokio etc. return
named but generic structures.  It's because it helps ensure that things like
`Send` bounds are automatically propagated as needed.

If instead one wraps it behind a generic function, then all bounds need to
be specified on the return value (so you'd need one for `_send` types and
one for non-send etc).

Prep for some other container cleanups.

---

