### PR TITLE
lib: Lower bitflags requirement to just "1"

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.4.0-alpha.0"
 anyhow = "1.0"
 async-compression = { version = "0.3", features = ["gzip", "tokio"] }
 bytes = "1.0.1"
-bitflags = "1.3.2"
+bitflags = "1"
 camino = "1.0.4"
 cjson = "0.1.1"
 flate2 = { features = ["zlib"], default_features = false, version = "1.0.20" }


### PR DESCRIPTION


This is dealt with in a newer nix but we need to match
what is locked in rpm-ostree right now.  See
https://github.com/nix-rust/nix/commit/5495bbce52d3541f90d13e692a1cef34e186e100

---

