### PR TITLE
lib/tar/write: Translate /etc → /usr/etc by default

### DIFF
--- a/lib/src/tar/write.rs
+++ b/lib/src/tar/write.rs
@@ -54,6 +54,7 @@ pub async fn write_tar(
         c.args(&[
             "--no-bindings",
             "--tar-autocreate-parents",
+            r#"--tar-pathname-filter=^etc(.*),usr/etc\1"#,
             "--tree=tar=/proc/self/fd/0",
             "--branch",
             refname,


### PR DESCRIPTION
We need this on general principle, because while ostree tries
to support both `/etc` and `/usr/etc`, in practice rpm-ostree
effectively requires ostree commits to have `/usr/etc`.