### PR TITLE
Add tokio_util module

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -27,6 +27,7 @@ pub mod container;
 pub mod diff;
 pub mod ima;
 pub mod tar;
+pub mod tokio_util;
 
 mod cmdext;
 

--- a/lib/src/tokio_util.rs
+++ b/lib/src/tokio_util.rs
@@ -1,0 +1,46 @@
+//! Helpers for bridging GLib async/mainloop with Tokio.
+
+use anyhow::Result;
+use futures_util::Future;
+use ostree::prelude::CancellableExt;
+
+/// Call a faillible future, while monitoring `cancellable` and return an error if cancelled.
+pub async fn run_with_cancellable<F, R>(f: F, cancellable: &ostree::gio::Cancellable) -> Result<R>
+where
+    F: Future<Output = Result<R>>,
+{
+    // Bridge GCancellable to a tokio notification
+    let notify = std::sync::Arc::new(tokio::sync::Notify::new());
+    let notify2 = notify.clone();
+    cancellable.connect_cancelled(move |_| notify2.notify_one());
+    cancellable.set_error_if_cancelled()?;
+    tokio::select! {
+       r = f => r,
+       _ = notify.notified() => {
+           Err(anyhow::anyhow!("Operation was cancelled"))
+       }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_cancellable() {
+        let cancellable = ostree::gio::Cancellable::new();
+
+        let cancellable_copy = cancellable.clone();
+        let s = async move {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            cancellable_copy.cancel();
+        };
+        let r = async move {
+            tokio::time::sleep(std::time::Duration::from_secs(200)).await;
+            Ok(())
+        };
+        let r = run_with_cancellable(r, &cancellable);
+        let (_, r) = tokio::join!(s, r);
+        assert!(r.is_err());
+    }
+}


### PR DESCRIPTION
This takes the code from https://github.com/coreos/rpm-ostree/blob/d6ed262f83b33e7fd454699b96661ba323d04128/rust/src/utils.rs#L163
which makes more sense here because:

- We depend on both glib and tokio and the code isn't rpm-ostree specific
- We will want to use this internally to ensure our worker threads
  get cancelled.