### PR TITLE
lib: Fix some rustdoc warnings

### DIFF
--- a/lib/src/container/imageproxy.rs
+++ b/lib/src/container/imageproxy.rs
@@ -1,6 +1,6 @@
 //! Run container-image-proxy as a subprocess.
 //! This allows fetching a container image manifest and layers in a streaming fashion.
-//! More information: https://github.com/cgwalters/container-image-proxy
+//! More information: <https://github.com/cgwalters/container-image-proxy>
 
 use super::{oci, ImageReference, Result};
 use crate::cmdext::CommandRedirectionExt;

--- a/lib/src/container/import.rs
+++ b/lib/src/container/import.rs
@@ -2,11 +2,11 @@
 //!
 //! # External depenendency on container-image-proxy
 //!
-//! This code requires https://github.com/cgwalters/container-image-proxy
+//! This code requires <https://github.com/cgwalters/container-image-proxy>
 //! installed as a binary in $PATH.
 //!
 //! The rationale for this is that while there exist Rust crates to speak
-//! the Docker distribution API, the Go library https://github.com/containers/image/
+//! the Docker distribution API, the Go library <https://github.com/containers/image/>
 //! supports key things we want for production use like:
 //!
 //! - Image mirroring and remapping; effectively `man containers-registries.conf`


### PR DESCRIPTION
URLs need `<>` wrapping.