### PR TITLE
lib: Bump to ostree 0.13.3

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -29,7 +29,7 @@ nix = "0.22.0"
 openat = "0.1.20"
 openat-ext = "0.2.0"
 openssl = "0.10.33"
-ostree = { features = ["v2021_4"], version = "0.13.2" }
+ostree = { features = ["v2021_5"], version = "0.13.3" }
 phf = { features = ["macros"], version = "0.9.0" }
 pin-project = "1.0"
 serde = { features = ["derive"], version = "1.0.125" }


### PR DESCRIPTION
And require v2021.5 because we do in practice for the fixed tar+selinux
bits.