### PR TITLE
Factor out internal `objgv` module with `gv!` incantations

### DIFF
--- a/lib/src/ima.rs
+++ b/lib/src/ima.rs
@@ -2,6 +2,7 @@
 
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use crate::objgv::*;
 use anyhow::{Context, Result};
 use fn_error_context::context;
 use gio::glib;
@@ -224,7 +225,7 @@ impl<'a> CommitRewriter<'a> {
             .load_variant(ostree::ObjectType::DirTree, checksum)?;
         let src = src.data_as_bytes();
         let src = src.try_as_aligned()?;
-        let src = gv!("(a(say)a(sayay))").cast(src);
+        let src = gv_dirtree!().cast(src);
         let (files, dirs) = src.to_tuple();
 
         // A reusable buffer to avoid heap allocating these
@@ -277,7 +278,7 @@ impl<'a> CommitRewriter<'a> {
 
         let commit_bytes = commit_v.data_as_bytes();
         let commit_bytes = commit_bytes.try_as_aligned()?;
-        let commit = gv!("(a{sv}aya(say)sstayay)").cast(commit_bytes);
+        let commit = gv_commit!().cast(commit_bytes);
         let commit = commit.to_tuple();
         let contents = &hex::encode(commit.6);
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -31,7 +31,7 @@ pub mod tar;
 pub mod tokio_util;
 
 mod cmdext;
-
+pub(crate) mod objgv;
 /// Prelude, intended for glob import.
 pub mod prelude {
     #[doc(hidden)]

--- a/lib/src/objgv.rs
+++ b/lib/src/objgv.rs
@@ -1,0 +1,31 @@
+/// Type representing an ostree commit object.
+macro_rules! gv_commit {
+    () => {
+        gvariant::gv!("(a{sv}aya(say)sstayay)")
+    };
+}
+pub(crate) use gv_commit;
+
+/// Type representing an ostree DIRTREE object.
+macro_rules! gv_dirtree {
+    () => {
+        gvariant::gv!("(a(say)a(sayay))")
+    };
+}
+pub(crate) use gv_dirtree;
+
+#[cfg(test)]
+mod tests {
+    use gvariant::aligned_bytes::TryAsAligned;
+    use gvariant::Marker;
+
+    use super::*;
+    #[test]
+    fn test_dirtree() {
+        // Just a compilation test
+        let data = b"".try_as_aligned().ok();
+        if let Some(data) = data {
+            let _t = gv_dirtree!().cast(data);
+        }
+    }
+}

--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -1,13 +1,13 @@
 //! APIs for creating container images from OSTree commits
 
-use crate::Result;
-
+use crate::objgv::*;
+use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use fn_error_context::context;
 use gio::glib;
 use gio::prelude::*;
 use gvariant::aligned_bytes::TryAsAligned;
-use gvariant::{gv, Marker, Structure};
+use gvariant::{Marker, Structure};
 use ostree::gio;
 use std::borrow::Cow;
 use std::collections::HashSet;
@@ -175,7 +175,7 @@ impl<'a, W: std::io::Write> OstreeMetadataWriter<'a, W> {
         self.append(ostree::ObjectType::DirTree, checksum, v)?;
         let v = v.data_as_bytes();
         let v = v.try_as_aligned()?;
-        let v = gv!("(a(say)a(sayay))").cast(v);
+        let v = gv_dirtree!().cast(v);
         let (files, dirs) = v.to_tuple();
 
         if let Some(c) = cancellable {
@@ -271,7 +271,7 @@ fn impl_export<W: std::io::Write>(
 
     let commit_v = commit_v.data_as_bytes();
     let commit_v = commit_v.try_as_aligned()?;
-    let commit = gv!("(a{sv}aya(say)sstayay)").cast(commit_v);
+    let commit = gv_commit!().cast(commit_v);
     let commit = commit.to_tuple();
     let contents = &hex::encode(commit.6);
     let metadata_checksum = &hex::encode(commit.7);


### PR DESCRIPTION
I plan to add some more code which uses this, so let's deduplicate
the hairy GVariant type strings.

I also tried to deduplicate this more by having a function or
macro that abstracts the `data_as_bytes()` and `try_as_aligned`
stuff, but couldn't figure out how to do it.