### PR TITLE
lib/oci: Make writer completion consume self

### DIFF
--- a/lib/src/container/export.rs
+++ b/lib/src/container/export.rs
@@ -45,7 +45,7 @@ fn build_oci(
     // Explicitly error if the target exists
     std::fs::create_dir(ocidir_path).context("Creating OCI dir")?;
     let ocidir = &openat::Dir::open(ocidir_path)?;
-    let writer = &mut oci::OciWriter::new(ocidir)?;
+    let mut writer = oci::OciWriter::new(ocidir)?;
 
     let commit = repo.resolve_rev(rev, false)?.unwrap();
     let commit = commit.as_str();

--- a/lib/src/container/oci.rs
+++ b/lib/src/container/oci.rs
@@ -175,7 +175,7 @@ impl<'a> OciWriter<'a> {
     }
 
     #[context("Writing OCI")]
-    pub(crate) fn complete(&mut self) -> Result<()> {
+    pub(crate) fn complete(self) -> Result<()> {
         let utsname = nix::sys::utsname::uname();
         let machine = utsname.machine();
         let arch = MACHINE_TO_OCI.get(machine).unwrap_or(&machine);
@@ -220,7 +220,7 @@ impl<'a> OciWriter<'a> {
                 size: rootfs_blob.blob.size,
                 digest: rootfs_blob.blob.digest_id(),
             }],
-            annotations: Some(self.manifest_annotations.drain().collect()),
+            annotations: Some(self.manifest_annotations),
         };
         let manifest_blob = write_json_blob(self.dir, &manifest)?;
 


### PR DESCRIPTION
This will allow us to pass ownership of e.g. annotations to
OCI data in the future.