### PR TITLE
cli: Add missing sysroot load

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -442,6 +442,7 @@ where
                     karg,
                 } => {
                     let sysroot = &ostree::Sysroot::new(Some(&gio::File::for_path(&sysroot)));
+                    sysroot.load(gio::NONE_CANCELLABLE)?;
                     let imgref = OstreeImageReference::try_from(imgref.as_str())?;
                     let kargs = karg.as_deref();
                     let kargs = kargs.map(|v| {


### PR DESCRIPTION
"Shouldn't we have CI tests that cover this?" you ask - yes, yes
we should.  Need to deduplicate infrastructure for this between this
and the main ostree repo - or between this and rpm-ostree.