### PR TITLE
container/deploy: Change origin key to match what rpm-ostree is using

### DIFF
--- a/lib/src/container/deploy.rs
+++ b/lib/src/container/deploy.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use ostree::glib;
 
 /// The key in the OSTree origin which holds a serialized [`super::OstreeImageReference`].
-pub const ORIGIN_CONTAINER: &str = "container";
+pub const ORIGIN_CONTAINER: &str = "container-image-reference";
 
 async fn pull_idempotent(repo: &ostree::Repo, imgref: &OstreeImageReference) -> Result<String> {
     let mut imp = super::store::LayeredImageImporter::new(repo, imgref).await?;
@@ -37,7 +37,7 @@ pub async fn deploy<'opts>(
     let repo = &sysroot.repo().unwrap();
     let commit = &pull_idempotent(repo, imgref).await?;
     let origin = glib::KeyFile::new();
-    origin.set_string("ostree", ORIGIN_CONTAINER, &imgref.to_string());
+    origin.set_string("origin", ORIGIN_CONTAINER, &imgref.to_string());
     let deployment = &sysroot.deploy_tree(
         Some(stateroot),
         commit,


### PR DESCRIPTION
The original higher level (sysroot oriented) code for container
bits was prototyped more in rpm-ostree, where we picked the key
`container-image-reference`.

When I went to write the deploy code here, I picked the key `container`
instead.  But, I think `container-image-reference` is more
self-explanatory.  No one is going to be typing this stuff by hand,
so verbosity is OK.

Now further, let's make the group `origin` matching the group for the
base `refspec` key.  (Again matching rpm-ostree too)
This makes `container-image-reference` feel as native as `refspec`
to ostree.