### PR TITLE
Dep cleanup

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -38,7 +38,6 @@ structopt = "0.3.21"
 tar = "0.4.33"
 tempfile = "3.2.0"
 tokio = { features = ["full"], version = "1" }
-tokio-stream = "0.1.5"
 tokio-util = { features = ["io"], version = "0.6" }
 tracing = "0.1"
 


### PR DESCRIPTION
lib: Drop unused `serde-plain`

I planned to use this I guess, but didn't.

---

lib: Remove clap/structopt from dev-dependencies

We expose the CLI as part of the library now.

---

lib: Remove `maplit`

It's unused.

---

lib: Remove `tokio-stream`

Not used since we switched to forking `skopeo`.

---

