### PR TITLE
lib/container: Use "encapsulate" terminology for module names too

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -13,7 +13,7 @@ use std::ffi::OsString;
 use structopt::StructOpt;
 
 use crate::container::store::{LayeredImageImporter, PrepareResult};
-use crate::container::{Config, ImageReference, ImportOptions, OstreeImageReference};
+use crate::container::{Config, ImageReference, OstreeImageReference, UnencapsulateOptions};
 
 fn parse_imgref(s: &str) -> Result<OstreeImageReference> {
     OstreeImageReference::try_from(s)
@@ -261,10 +261,10 @@ async fn container_import(
     } else {
         None
     };
-    let opts = ImportOptions {
+    let opts = UnencapsulateOptions {
         progress: Some(tx_progress),
     };
-    let import = crate::container::import(repo, &imgref, Some(opts));
+    let import = crate::container::unencapsulate(repo, &imgref, Some(opts));
     tokio::pin!(import);
     tokio::pin!(rx_progress);
     let import = loop {
@@ -316,7 +316,7 @@ async fn container_export(
         labels: Some(labels),
         cmd,
     };
-    let pushed = crate::container::export(repo, rev, &config, &imgref).await?;
+    let pushed = crate::container::encapsulate(repo, rev, &config, &imgref).await?;
     println!("{}", pushed);
     Ok(())
 }

--- a/lib/src/container/encapsulate.rs
+++ b/lib/src/container/encapsulate.rs
@@ -144,7 +144,7 @@ async fn build_impl(
             sigverify: SignatureSource::ContainerPolicyAllowInsecure,
             imgref: dest.to_owned(),
         };
-        let (_, digest) = super::import::fetch_manifest(&imgref).await?;
+        let (_, digest) = super::unencapsulate::fetch_manifest(&imgref).await?;
         Ok(digest)
     }
 }
@@ -152,7 +152,7 @@ async fn build_impl(
 /// Given an OSTree repository and ref, generate a container image.
 ///
 /// The returned `ImageReference` will contain a digested (e.g. `@sha256:`) version of the destination.
-pub async fn export<S: AsRef<str>>(
+pub async fn encapsulate<S: AsRef<str>>(
     repo: &ostree::Repo,
     ostree_ref: S,
     config: &Config,

--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -229,10 +229,10 @@ impl std::fmt::Display for OstreeImageReference {
 }
 
 pub mod deploy;
-mod export;
-pub use export::*;
-mod import;
-pub use import::*;
+mod encapsulate;
+pub use encapsulate::*;
+mod unencapsulate;
+pub use unencapsulate::*;
 mod ociwriter;
 mod skopeo;
 pub mod store;


### PR DESCRIPTION
Previously in https://github.com/ostreedev/ostree-rs-ext/pull/113
we changed the CLI entrypoints with this rationale:

> Since we're moving towards more "native" support for container
> images, we need to very clearly differentiate between the code
> that currently uses the terms "import" and "export" which are
> somewhat ambiguous.

To elaborate, the term "import" is ambiguous with respect to our
container "store" path, which generates a new ostree commit and
operates on arbitrary container images.

Let's take the next step now and rename the modules too.