### PR TITLE
Clean up `deny/forbid` bits

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,7 @@
+// Good defaults
+#![forbid(unused_must_use)]
+#![deny(unsafe_code)]
+
 use anyhow::Result;
 
 async fn run() -> Result<()> {

--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -25,11 +25,6 @@
 //! A key feature of container images is support for layering.  At the moment, support
 //! for this is [planned but not implemented](https://github.com/ostreedev/ostree-rs-ext/issues/12).
 
-//#![deny(missing_docs)]
-// Good defaults
-#![forbid(unused_must_use)]
-#![deny(unsafe_code)]
-
 use anyhow::anyhow;
 use std::borrow::Cow;
 use std::convert::{TryFrom, TryInto};

--- a/lib/src/tar/mod.rs
+++ b/lib/src/tar/mod.rs
@@ -32,11 +32,6 @@
 //! to have the container runtime try to unpack and apply those.  For this reason, this module
 //! serializes extended attributes into separate `.xattr` files associated with each ostree object.
 
-//#![deny(missing_docs)]
-// Good defaults
-#![forbid(unused_must_use)]
-#![deny(unsafe_code)]
-
 mod import;
 pub use import::*;
 mod export;


### PR DESCRIPTION
We had duplicate versions of these inside the `mod.rs`; the
versions in the top level `lib.rs` are all that are needed.

However, because the cli is a separate unit, copy them there too.
Not that there's actually anything actually *in* the cli `main.rs`,
but it's a good best practice in case the code does grow for some
reason, or it gets cargo culted elsewhere.