### PR TITLE
container: Rework API and model around "base commit" and "merge commit"

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -334,7 +334,7 @@ async fn container_store(repo: &str, imgref: &OstreeImageReference) -> Result<()
     let mut imp = LayeredImageImporter::new(repo, &imgref).await?;
     let prep = match imp.prepare().await? {
         PrepareResult::AlreadyPresent(c) => {
-            println!("No changes in {} => {}", imgref, c);
+            println!("No changes in {} => {}", imgref, c.merge_commit);
             return Ok(());
         }
         PrepareResult::Ready(r) => r,

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -366,10 +366,7 @@ async fn container_store(repo: &str, imgref: &OstreeImageReference) -> Result<()
             }
         }
     }
-    println!(
-        "Wrote: {} => {} => {}",
-        imgref, import.ostree_ref, import.commit
-    );
+    println!("Wrote: {} => {}", imgref, import.state.merge_commit);
     Ok(())
 }
 

--- a/lib/src/container/deploy.rs
+++ b/lib/src/container/deploy.rs
@@ -11,7 +11,7 @@ pub const ORIGIN_CONTAINER: &str = "container-image-reference";
 async fn pull_idempotent(repo: &ostree::Repo, imgref: &OstreeImageReference) -> Result<String> {
     let mut imp = super::store::LayeredImageImporter::new(repo, imgref).await?;
     match imp.prepare().await? {
-        PrepareResult::AlreadyPresent(r) => Ok(r),
+        PrepareResult::AlreadyPresent(r) => Ok(r.merge_commit),
         PrepareResult::Ready(prep) => Ok(imp.import(prep).await?.commit),
     }
 }

--- a/lib/src/container/deploy.rs
+++ b/lib/src/container/deploy.rs
@@ -37,6 +37,9 @@ pub async fn deploy<'opts>(
     let options = options.unwrap_or_default();
     let repo = &sysroot.repo().unwrap();
     let mut imp = super::store::LayeredImageImporter::new(repo, imgref).await?;
+    if let Some(target) = options.target_imgref {
+        imp.set_target(target);
+    }
     let state = match imp.prepare().await? {
         PrepareResult::AlreadyPresent(r) => r,
         PrepareResult::Ready(prep) => imp.import(prep).await?.state,

--- a/lib/src/container/deploy.rs
+++ b/lib/src/container/deploy.rs
@@ -8,15 +8,6 @@ use ostree::glib;
 /// The key in the OSTree origin which holds a serialized [`super::OstreeImageReference`].
 pub const ORIGIN_CONTAINER: &str = "container-image-reference";
 
-async fn pull_idempotent(repo: &ostree::Repo, imgref: &OstreeImageReference) -> Result<String> {
-    let mut imp = super::store::LayeredImageImporter::new(repo, imgref).await?;
-    let state = match imp.prepare().await? {
-        PrepareResult::AlreadyPresent(r) => r,
-        PrepareResult::Ready(prep) => imp.import(prep).await?.state,
-    };
-    Ok(state.merge_commit)
-}
-
 /// Options configuring deployment.
 #[derive(Debug, Default)]
 pub struct DeployOpts<'a> {
@@ -45,7 +36,12 @@ pub async fn deploy<'opts>(
     let cancellable = ostree::gio::NONE_CANCELLABLE;
     let options = options.unwrap_or_default();
     let repo = &sysroot.repo().unwrap();
-    let commit = &pull_idempotent(repo, imgref).await?;
+    let mut imp = super::store::LayeredImageImporter::new(repo, imgref).await?;
+    let state = match imp.prepare().await? {
+        PrepareResult::AlreadyPresent(r) => r,
+        PrepareResult::Ready(prep) => imp.import(prep).await?.state,
+    };
+    let commit = state.get_commit();
     let origin = glib::KeyFile::new();
     let target_imgref = options.target_imgref.unwrap_or(imgref);
     origin.set_string("origin", ORIGIN_CONTAINER, &target_imgref.to_string());

--- a/lib/src/container/deploy.rs
+++ b/lib/src/container/deploy.rs
@@ -10,10 +10,11 @@ pub const ORIGIN_CONTAINER: &str = "container-image-reference";
 
 async fn pull_idempotent(repo: &ostree::Repo, imgref: &OstreeImageReference) -> Result<String> {
     let mut imp = super::store::LayeredImageImporter::new(repo, imgref).await?;
-    match imp.prepare().await? {
-        PrepareResult::AlreadyPresent(r) => Ok(r.merge_commit),
-        PrepareResult::Ready(prep) => Ok(imp.import(prep).await?.commit),
-    }
+    let state = match imp.prepare().await? {
+        PrepareResult::AlreadyPresent(r) => r,
+        PrepareResult::Ready(prep) => imp.import(prep).await?.state,
+    };
+    Ok(state.merge_commit)
 }
 
 /// Options configuring deployment.

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -53,6 +53,22 @@ pub struct LayeredImageState {
     pub manifest_digest: String,
 }
 
+impl LayeredImageState {
+    /// Return the default ostree commit digest for this image.
+    ///
+    /// If this is a non-layered image, the merge commit will be
+    /// ignored, and the base commit returned.
+    ///
+    /// Otherwise, this returns the merge commit.
+    pub fn get_commit(&self) -> &str {
+        if self.is_layered {
+            self.merge_commit.as_str()
+        } else {
+            self.base_commit.as_str()
+        }
+    }
+}
+
 /// Context for importing a container image.
 pub struct LayeredImageImporter {
     repo: ostree::Repo,

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -466,7 +466,7 @@ async fn test_container_write_derive() -> Result<()> {
             panic!("Should have already imported {}", import.ostree_ref)
         }
     };
-    assert_eq!(import.commit, already_present);
+    assert_eq!(import.commit, already_present.merge_commit);
 
     // Test upgrades; replace the oci-archive with new content.
     std::fs::write(exampleos_path, EXAMPLEOS_DERIVED_V2_OCI)?;
@@ -486,7 +486,7 @@ async fn test_container_write_derive() -> Result<()> {
     }
     let import = imp.import(prep).await?;
     // New commit.
-    assert_ne!(import.commit, already_present);
+    assert_ne!(import.commit, already_present.merge_commit);
     // We should still have exactly one image stored.
     let images = ostree_ext::container::store::list_images(&fixture.destrepo)?;
     assert_eq!(images.len(), 1);
@@ -513,7 +513,7 @@ async fn test_container_write_derive() -> Result<()> {
             panic!("Should have already imported {}", import.ostree_ref)
         }
     };
-    assert_eq!(import.commit, already_present);
+    assert_eq!(import.commit, already_present.merge_commit);
 
     // Create a new repo, and copy to it
     let destrepo2 = ostree::Repo::create_at(


### PR DESCRIPTION
containers: Expose a state struct with base commit and layering state

This is actually quite analogous to what rpm-ostree does internally;
a lot of the internals there distinguish "base" versus "layered"
commits, and this is very similar.

Here, when we import a non-layered image, we can mostly
ignore the merge commit since all it has is the image manifest.
The base image layer ref *is* the encapsulated ostree commit with
all the metadata injected by (rpm-)ostree in the non-layered case.

Add an API which exposes this as a struct, and also return it
from the importer's `AlreadyPresent` case.

---

container: Change import result case to contain state struct

Notably, this also stops exposing the ostree ref for the merge commit,
which I think is a good idea in general since it should be thought
of more as an implementation detail.

In other words, this module speaks container image references
and ostree commits.

---

container/deploy: Use base commit if we're not layered

If we're not doing a layered image, then use the base commit
for the deployment.

Closes: https://github.com/ostreedev/ostree-rs-ext/issues/143

---

container/deploy: Also write ref with target if provided

With this new emphasis on "dual commit objects" for the container
deployment, the higher level code queries via container image references
and we don't expose the ostree ref (since there is no longer a single
one).

This makes it critical to write the internal ref matching the
target container image, because it now needs to match the origin.

---

