### PR TITLE
Tracing and containers-image-proxy 0.2

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.4.0"
 
 [dependencies]
 anyhow = "1.0"
-containers-image-proxy = "0.1"
+containers-image-proxy = "0.2"
 async-compression = { version = "0.3", features = ["gzip", "tokio"] }
 bytes = "1.0.1"
 bitflags = "1"

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -173,7 +173,7 @@ pub fn manifest_digest_from_commit(commit: &glib::Variant) -> Result<String> {
 impl LayeredImageImporter {
     /// Create a new importer.
     pub async fn new(repo: &ostree::Repo, imgref: &OstreeImageReference) -> Result<Self> {
-        let proxy = ImageProxy::new().await?;
+        let mut proxy = ImageProxy::new().await?;
         let proxy_img = proxy.open_image(&imgref.imgref.to_string()).await?;
         let repo = repo.clone();
         Ok(LayeredImageImporter {
@@ -255,7 +255,7 @@ impl LayeredImageImporter {
 
     /// Import a layered container image
     pub async fn import(self, import: Box<PreparedImport>) -> Result<CompletedImport> {
-        let proxy = self.proxy;
+        let mut proxy = self.proxy;
         let target_imgref = self.target_imgref.as_ref().unwrap_or(&self.imgref);
         let ostree_ref = ref_for_image(&target_imgref.imgref)?;
         // First download the base image (if necessary) - we need the SELinux policy
@@ -266,7 +266,7 @@ impl LayeredImageImporter {
         } else {
             let base_layer_ref = &base_layer.layer;
             let (blob, driver) = super::unencapsulate::fetch_layer_decompress(
-                &proxy,
+                &mut proxy,
                 &self.proxy_img,
                 &base_layer.layer,
             )
@@ -294,7 +294,7 @@ impl LayeredImageImporter {
                 layer_commits.push(c.to_string());
             } else {
                 let (blob, driver) = super::unencapsulate::fetch_layer_decompress(
-                    &proxy,
+                    &mut proxy,
                     &self.proxy_img,
                     &layer.layer,
                 )

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -290,6 +290,7 @@ impl LayeredImageImporter {
         let mut layer_filtered_content = BTreeMap::new();
         for layer in import.layers {
             if let Some(c) = layer.commit {
+                tracing::debug!("Reusing fetched commit {}", c);
                 layer_commits.push(c.to_string());
             } else {
                 let (blob, driver) = super::unencapsulate::fetch_layer_decompress(
@@ -318,6 +319,7 @@ impl LayeredImageImporter {
 
         // We're done with the proxy, make sure it didn't have any errors.
         proxy.finalize().await?;
+        tracing::debug!("finalized proxy");
 
         let serialized_manifest = serde_json::to_string(&import.manifest)?;
         let mut metadata = HashMap::new();
@@ -420,6 +422,7 @@ fn query_image_impl(
         is_layered,
         manifest_digest,
     };
+    tracing::debug!(state = ?state);
     Ok(Some((manifest, state)))
 }
 

--- a/lib/src/container/unencapsulate.rs
+++ b/lib/src/container/unencapsulate.rs
@@ -160,6 +160,7 @@ fn new_async_decompressor<'a>(
 }
 
 /// A wrapper for [`get_blob`] which fetches a layer and decompresses it.
+#[instrument(skip(proxy, img))]
 pub(crate) async fn fetch_layer_decompress<'a>(
     proxy: &'a ImageProxy,
     img: &OpenedImage,


### PR DESCRIPTION
Add some more tracing in container path

Seeing a hang in upgrades in rpm-ostree, this may help debug.

---

container: Bump to containers-image-proxy 0.2

This requires threading `mut` around more.  Motivated by
improved logging/debugging.

---

