### PR TITLE
container/store: Write filter data to commitmeta, clean up API

### DIFF
--- a/lib/src/container/deploy.rs
+++ b/lib/src/container/deploy.rs
@@ -42,7 +42,7 @@ pub async fn deploy<'opts>(
     }
     let state = match imp.prepare().await? {
         PrepareResult::AlreadyPresent(r) => r,
-        PrepareResult::Ready(prep) => imp.import(prep).await?.state,
+        PrepareResult::Ready(prep) => imp.import(prep).await?,
     };
     let commit = state.get_commit();
     let origin = glib::KeyFile::new();

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -446,7 +446,7 @@ async fn test_container_write_derive() -> Result<()> {
 
     let imported_commit = &fixture
         .destrepo
-        .load_commit(import.state.merge_commit.as_str())?
+        .load_commit(import.merge_commit.as_str())?
         .0;
     let digest = ostree_ext::container::store::manifest_digest_from_commit(imported_commit)?;
     assert!(digest.starts_with("sha256:"));
@@ -456,7 +456,7 @@ async fn test_container_write_derive() -> Result<()> {
     bash!(
         "ostree --repo={repo} ls {r} /usr/share/anewfile",
         repo = fixture.destrepo_path.as_str(),
-        r = import.state.merge_commit.as_str()
+        r = import.merge_commit.as_str()
     )?;
 
     // Import again, but there should be no changes.
@@ -469,7 +469,7 @@ async fn test_container_write_derive() -> Result<()> {
             panic!("Should have already imported {}", &exampleos_ref)
         }
     };
-    assert_eq!(import.state.merge_commit, already_present.merge_commit);
+    assert_eq!(import.merge_commit, already_present.merge_commit);
 
     // Test upgrades; replace the oci-archive with new content.
     std::fs::write(exampleos_path, EXAMPLEOS_DERIVED_V2_OCI)?;
@@ -489,7 +489,7 @@ async fn test_container_write_derive() -> Result<()> {
     }
     let import = imp.import(prep).await?;
     // New commit.
-    assert_ne!(import.state.merge_commit, already_present.merge_commit);
+    assert_ne!(import.merge_commit, already_present.merge_commit);
     // We should still have exactly one image stored.
     let images = ostree_ext::container::store::list_images(&fixture.destrepo)?;
     assert_eq!(images.len(), 1);
@@ -503,7 +503,7 @@ async fn test_container_write_derive() -> Result<()> {
          fi
         ",
         repo = fixture.destrepo_path.as_str(),
-        r = import.state.merge_commit.as_str()
+        r = import.merge_commit.as_str()
     )?;
 
     // And there should be no changes on upgrade again.
@@ -516,7 +516,7 @@ async fn test_container_write_derive() -> Result<()> {
             panic!("Should have already imported {}", &exampleos_ref)
         }
     };
-    assert_eq!(import.state.merge_commit, already_present.merge_commit);
+    assert_eq!(import.merge_commit, already_present.merge_commit);
 
     // Create a new repo, and copy to it
     let destrepo2 = ostree::Repo::create_at(


### PR DESCRIPTION
The import path was previously providing the data about filtered-out
content (e.g. files in `/var`) "out of band" as part of the import
return value.  But this means that unless that data is e.g. logged
it ends up being lost.

Since the amount of data is bounded, let's instead add it as metadata
to the merge commit.

Then this lets us make a nice cleanup of entirely dropping the
`CompletedImport` struct in favor of the `LayeredImageState` that
we use in various places.

Now it's possible for something like `rpm-ostree status` to also
reliably show how many files were filtered out of each layer.