### PR TITLE
container: Add options struct for encapsulation

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -317,7 +317,8 @@ async fn container_export(
         labels: Some(labels),
         cmd,
     };
-    let pushed = crate::container::encapsulate(repo, rev, &config, imgref).await?;
+    let opts = Some(Default::default());
+    let pushed = crate::container::encapsulate(repo, rev, &config, opts, &imgref).await?;
     println!("{}", pushed);
     Ok(())
 }

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -326,10 +326,15 @@ async fn test_container_import_export() -> Result<()> {
         ),
         cmd: Some(vec!["/bin/bash".to_string()]),
     };
-    let digest =
-        ostree_ext::container::encapsulate(&fixture.srcrepo, TESTREF, &config, &srcoci_imgref)
-            .await
-            .context("exporting")?;
+    let digest = ostree_ext::container::encapsulate(
+        &fixture.srcrepo,
+        TESTREF,
+        &config,
+        None,
+        &srcoci_imgref,
+    )
+    .await
+    .context("exporting")?;
     assert!(srcoci_path.exists());
 
     let inspect = skopeo_inspect(&srcoci_imgref.to_string())?;
@@ -560,7 +565,7 @@ async fn test_container_import_export_registry() -> Result<()> {
         ..Default::default()
     };
     let digest =
-        ostree_ext::container::encapsulate(&fixture.srcrepo, TESTREF, &config, &src_imgref)
+        ostree_ext::container::encapsulate(&fixture.srcrepo, TESTREF, &config, None, &src_imgref)
             .await
             .context("exporting to registry")?;
     let mut digested_imgref = src_imgref.clone();


### PR DESCRIPTION
This exposes the ability to disable compression, which is mostly
only useful for the internal flow that pushes to containers/storage
where we don't want compression.

But the main goal here is to pave the way for adding a `bool chunking`.