### PR TITLE
cli: Use `..Default::default()` for proxy options

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -243,6 +243,7 @@ impl Into<ostree_container::store::ImageProxyConfig> for ContainerProxyOpts {
         ostree_container::store::ImageProxyConfig {
             authfile: self.authfile,
             insecure_skip_tls_verification: Some(self.insecure_skip_tls_verification),
+            ..Default::default()
         }
     }
 }


### PR DESCRIPTION
This way it's not a breaking change to add a new member to the
struct.