### PR TITLE
tar/import: Use the correct API to read link name

### DIFF
--- a/lib/src/tar/import.rs
+++ b/lib/src/tar/import.rs
@@ -284,7 +284,6 @@ impl Importer {
     ) -> Result<()> {
         let (uid, gid, _) = header_attrs(entry.header())?;
         let target = entry
-            .header()
             .link_name()?
             .ok_or_else(|| anyhow!("Invalid symlink"))?;
         let target = target


### PR DESCRIPTION
The `entry::header().link_name()` path doesn't support long links,
and this is a documented foot-gun.  Use `entry::link_name()` instead.

Needed for e.g.
`/ostree/repo/objects/87/c8834da3bad596352375ff413bca064584f184bdd6ba1764293d137249e168.file -> ../../../../usr/lib64/qt5/plugins/wayland-graphics-integration-server/libqt-wayland-compositor-xcomposite-egl.so`.