### PR TITLE
tar/import: Write commitpartial state

### DIFF
--- a/lib/src/tar/import.rs
+++ b/lib/src/tar/import.rs
@@ -523,6 +523,8 @@ impl Importer {
                 ostree::RepoVerifyFlags::empty(),
             )?;
 
+            self.repo.mark_commit_partial(&checksum, true)?;
+
             // Write the commit object, which also verifies its checksum.
             let actual_checksum =
                 self.repo
@@ -534,6 +536,8 @@ impl Importer {
             self.repo
                 .write_commit_detached_metadata(&checksum, Some(&commitmeta), cancellable)?;
         } else {
+            self.repo.mark_commit_partial(&checksum, true)?;
+
             // We're not doing any validation of the commit, so go ahead and write it.
             let actual_checksum =
                 self.repo
@@ -571,6 +575,8 @@ impl Importer {
             }
         }
         txn.commit(cancellable)?;
+
+        self.repo.mark_commit_partial(&checksum, false)?;
 
         Ok(checksum)
     }

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -226,13 +226,14 @@ async fn test_tar_import_signed() -> Result<()> {
         }),
     )
     .await?;
-    let (commitdata, _) = fixture.destrepo.load_commit(&imported)?;
+    let (commitdata, state) = fixture.destrepo.load_commit(&imported)?;
     assert_eq!(
         EXAMPLEOS_CONTENT_CHECKSUM,
         ostree::commit_get_content_checksum(&commitdata)
             .unwrap()
             .as_str()
     );
+    assert_eq!(state, ostree::RepoCommitState::NORMAL);
     Ok(())
 }
 


### PR DESCRIPTION
This mirrors the logic in `ostree_repo_pull()` - before
we write the commit object, we want to mark it as partial so
the core knows objects are still being written.  And after the
transaction, undo that marker.

Motivated by supporting "chunked" containers (split tar) where
this partial state will be more obvious.