### PR TITLE
A few small patches for `tar/import`

### DIFF
--- a/lib/src/tar/import.rs
+++ b/lib/src/tar/import.rs
@@ -51,12 +51,6 @@ struct Importer {
     stats: ImportStats,
 }
 
-impl Drop for Importer {
-    fn drop(&mut self) {
-        let _ = self.repo.abort_transaction(gio::NONE_CANCELLABLE);
-    }
-}
-
 /// Validate size/type of a tar header for OSTree metadata object.
 fn validate_metadata_header(header: &tar::Header, desc: &str) -> Result<usize> {
     if header.entry_type() != tar::EntryType::Regular {


### PR DESCRIPTION
tar/import: Remove unnecessary `abort_transaction()`

This is dead code since b7ba07556c8c54a719f47d9a8f1ef47b5b7a0e4b
when we switched to `auto_transaction()`.

---

tar/import: Move directory filtering into filter function

It's cleaner if our `filter_entry` function does most of the
work here instead of having half of the filtering in a closure.

---

tar/import: Move txn outside of `Importer`

This is prep for split tar imports, where we'll reuse distinct
calls to the importer across a single transaction.

---

