### PR TITLE
tar/export: Fix numeric export for objects directories

### DIFF
--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -83,7 +83,7 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
             h.set_gid(0);
             h.set_mode(0o755);
             h.set_size(0);
-            let path = format!("{}/repo/objects/{:#04x}", OSTREEDIR, d);
+            let path = format!("{}/repo/objects/{:02x}", OSTREEDIR, d);
             self.out.append_data(&mut h, &path, &mut std::io::empty())?;
         }
 


### PR DESCRIPTION
Currently it looks like `sysroot/ostree/repo/objects/0xf5`
when it should obviously be
`sysroot/ostree/repo/objects/f5`.

Reported by @giuseppe 