### PR TITLE
 tar/export: Create all parent directories too

### DIFF
--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -69,6 +69,18 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
         }
     }
 
+    /// Add a directory entry with default permissions (root/root 0755)
+    fn append_default_dir(&mut self, path: &Utf8Path) -> Result<()> {
+        let mut h = tar::Header::new_gnu();
+        h.set_entry_type(tar::EntryType::Directory);
+        h.set_uid(0);
+        h.set_gid(0);
+        h.set_mode(0o755);
+        h.set_size(0);
+        self.out.append_data(&mut h, &path, &mut std::io::empty())?;
+        Ok(())
+    }
+
     /// Write the initial directory structure.
     fn write_initial_directories(&mut self) -> Result<()> {
         if self.wrote_initdirs {
@@ -77,25 +89,13 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
         self.wrote_initdirs = true;
         // Object subdirectories
         for d in 0..0xFF {
-            let mut h = tar::Header::new_gnu();
-            h.set_entry_type(tar::EntryType::Directory);
-            h.set_uid(0);
-            h.set_gid(0);
-            h.set_mode(0o755);
-            h.set_size(0);
-            let path = format!("{}/repo/objects/{:02x}", OSTREEDIR, d);
-            self.out.append_data(&mut h, &path, &mut std::io::empty())?;
+            let path: Utf8PathBuf = format!("{}/repo/objects/{:02x}", OSTREEDIR, d).into();
+            self.append_default_dir(&path)?;
         }
 
         // The special `repo/xattrs` directory used only in our tar serialization.
-        let mut h = tar::Header::new_gnu();
-        h.set_entry_type(tar::EntryType::Directory);
-        h.set_uid(0);
-        h.set_gid(0);
-        h.set_mode(0o755);
-        h.set_size(0);
-        let path = format!("{}/repo/xattrs", OSTREEDIR);
-        self.out.append_data(&mut h, &path, &mut std::io::empty())?;
+        let path: Utf8PathBuf = format!("{}/repo/xattrs", OSTREEDIR).into();
+        self.append_default_dir(&path)?;
         Ok(())
     }
 

--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -87,9 +87,24 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
             return Ok(());
         }
         self.wrote_initdirs = true;
+
+        let objdir: Utf8PathBuf = format!("{}/repo/objects", OSTREEDIR).into();
+        // Add all parent directories
+        let parent_dirs = {
+            let mut parts: Vec<_> = objdir.ancestors().collect();
+            parts.reverse();
+            parts
+        };
+        for path in parent_dirs {
+            match path.as_str() {
+                "/" | "" => continue,
+                _ => {}
+            }
+            self.append_default_dir(&path)?;
+        }
         // Object subdirectories
         for d in 0..0xFF {
-            let path: Utf8PathBuf = format!("{}/repo/objects/{:02x}", OSTREEDIR, d).into();
+            let path: Utf8PathBuf = format!("{}/{:02x}", objdir, d).into();
             self.append_default_dir(&path)?;
         }
 

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -237,6 +237,21 @@ async fn test_tar_import_signed() -> Result<()> {
     Ok(())
 }
 
+/// Validate basic structure of the tar export.
+/// Right now just checks the first entry is `sysroot` with mode 0755.
+#[test]
+fn test_tar_export_structure() -> Result<()> {
+    let fixture = Fixture::new()?;
+    let src_tar = initial_export(&fixture)?;
+    let src_tar = std::io::BufReader::new(std::fs::File::open(&src_tar)?);
+    let mut src_tar = tar::Archive::new(src_tar);
+    let first = src_tar.entries()?.next().unwrap()?;
+    let firstpath = first.path()?;
+    assert_eq!(firstpath.to_str().unwrap(), "sysroot");
+    assert_eq!(first.header().mode()?, 0o755);
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_tar_import_export() -> Result<()> {
     let fixture = Fixture::new()?;


### PR DESCRIPTION
tar: Factor out helper to write default directory

Prep for ensuring we create all parent dirs to aid containers/storage.

---

tar/export: Create all parent directories too

This is really the standard/expected thing to do.  The current
containers/storage stack handles this, but the experimental chunked
back end did not until
https://github.com/containers/storage/pull/1072/commits/501611fd510f3406aab3acf25b18545d321ebb79

---

