### PR TITLE
ci: add GH workflow for Minimum Supported Rust Version (MSRV)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,12 +14,13 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Minimum supported Rust version (MSRV)
+  ACTION_MSRV_TOOLCHAIN: 1.54.0
 
 jobs:
   build:
     runs-on: ubuntu-latest
     container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
-
     steps:
       - uses: actions/checkout@v2
       - name: Install deps
@@ -33,3 +34,23 @@ jobs:
         run: cargo test --no-run
       - name: Run tests
         run: cargo test -- --nocapture --quiet
+  build-minimum-toolchain:
+    name: "Build, minimum supported toolchain (MSRV)"
+    runs-on: ubuntu-latest
+    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install deps
+        run: ./ci/installdeps.sh
+      - name: Remove system Rust toolchain
+        run: dnf remove -y rust cargo
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN']  }}
+          default: true
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
+      - name: cargo build (release)
+        run: cargo build --release


### PR DESCRIPTION
This adds a new CI jobs to make sure the code is building fine under
a given MSRV. It mostly helps making sure we stay compatible with
system toolchains shipped by distros (e.g. RHEL8).
This keeps using system dependencies from FCOS buildroot (notably,
a fresh ostree), but it drop the installed toolchain in favor
of a CI-pinned one.