### PR TITLE
ci: add GH workflow for linting 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ env:
   CARGO_TERM_COLOR: always
   # Minimum supported Rust version (MSRV)
   ACTION_MSRV_TOOLCHAIN: 1.54.0
+  # Pinned toolchain for linting
+  ACTION_LINTS_TOOLCHAIN: 1.56.0
 
 jobs:
   build:
@@ -25,8 +27,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install deps
         run: ./ci/installdeps.sh
-      - name: Format
-        run: cargo fmt -- --check -l
       # xref containers/containers-image-proxy-rs
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
@@ -54,3 +54,24 @@ jobs:
         uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
       - name: cargo build (release)
         run: cargo build --release
+  linting:
+    name: "Lints, pinned toolchain"
+    runs-on: ubuntu-latest
+    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install deps
+        run: ./ci/installdeps.sh
+      - name: Remove system Rust toolchain
+        run: dnf remove -y rust cargo
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env['ACTION_LINTS_TOOLCHAIN']  }}
+          default: true
+          components: rustfmt, clippy
+      - name: cargo fmt (check)
+        run: cargo fmt -- --check -l
+      - name: cargo clippy (warnings)
+        run: cargo clippy -- -D warnings

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -238,6 +238,7 @@ enum Opt {
     ImaSign(ImaSignOpts),
 }
 
+#[allow(clippy::from_over_into)]
 impl Into<ostree_container::store::ImageProxyConfig> for ContainerProxyOpts {
     fn into(self) -> ostree_container::store::ImageProxyConfig {
         ostree_container::store::ImageProxyConfig {
@@ -346,7 +347,7 @@ async fn container_export(
         cmd,
     };
     let opts = Some(Default::default());
-    let pushed = crate::container::encapsulate(repo, rev, &config, opts, &imgref).await?;
+    let pushed = crate::container::encapsulate(repo, rev, &config, opts, imgref).await?;
     println!("{}", pushed);
     Ok(())
 }

--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -100,7 +100,7 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
                 "/" | "" => continue,
                 _ => {}
             }
-            self.append_default_dir(&path)?;
+            self.append_default_dir(path)?;
         }
         // Object subdirectories
         for d in 0..0xFF {


### PR DESCRIPTION
This fixes the following warnings highlighted by clippy:
 * https://rust-lang.github.io/rust-clippy/master/index.html#from_over_into
 * https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

It also adds a new CI job dedicated to linting, which includes steps for
rustfmt and clippy.