### PR TITLE
Add some missing `#[derive(Debug)]`

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -12,7 +12,6 @@ version = "0.5.1"
 anyhow = "1.0"
 containers-image-proxy = "0.3"
 async-compression = { version = "0.3", features = ["gzip", "tokio"] }
-bytes = "1.0.1"
 bitflags = "1"
 camino = "1.0.4"
 cjson = "0.1.1"

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -81,6 +81,7 @@ impl LayeredImageState {
 }
 
 /// Context for importing a container image.
+#[derive(Debug)]
 pub struct LayeredImageImporter {
     repo: ostree::Repo,
     proxy: ImageProxy,
@@ -90,6 +91,7 @@ pub struct LayeredImageImporter {
 }
 
 /// Result of invoking [`LayeredImageImporter::prepare`].
+#[derive(Debug)]
 pub enum PrepareResult {
     /// The image reference is already present; the contained string is the OSTree commit.
     AlreadyPresent(LayeredImageState),

--- a/lib/src/container/unencapsulate.rs
+++ b/lib/src/container/unencapsulate.rs
@@ -51,6 +51,7 @@ type Progress = tokio::sync::watch::Sender<UnencapsulationProgress>;
 
 /// A read wrapper that updates the download progress.
 #[pin_project::pin_project]
+#[derive(Debug)]
 struct ProgressReader<T> {
     #[pin]
     reader: T,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -5,6 +5,7 @@
 //! written in Rust.  
 
 #![deny(missing_docs)]
+#![deny(missing_debug_implementations)]
 // Good defaults
 #![forbid(unused_must_use)]
 #![deny(unsafe_code)]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -4,9 +4,10 @@
 //! and the Rust bindings to it, adding new functionality
 //! written in Rust.  
 
+// See https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
-// Good defaults
+#![deny(unreachable_pub)]
 #![forbid(unused_must_use)]
 #![deny(unsafe_code)]
 #![cfg_attr(feature = "dox", feature(doc_cfg))]

--- a/lib/src/tar/write.rs
+++ b/lib/src/tar/write.rs
@@ -36,6 +36,7 @@ pub struct WriteTarOptions {
 ///
 /// This includes some basic data on the number of files that were filtered
 /// out because they were not in `/usr`.
+#[derive(Debug, Default)]
 pub struct WriteTarResult {
     /// The resulting OSTree commit SHA-256.
     pub commit: String,


### PR DESCRIPTION
Add some missing `#[derive(Debug)]`

Hit this when I wanted to add `dbg!`.

---

Drop ununused `bytes` dependency

We aren't doing HTTP directly anymore.

---

lib: Also add `unreachable_pub` to opted-in lint

And link to the list.

I plan to cargo cult this elsewhere.

---

