### PR TITLE
lib/cargo: update stale dependencies

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -23,13 +23,13 @@ hex = "0.4.3"
 indicatif = "0.16.0"
 lazy_static = "1.4.0"
 libc = "0.2.92"
-nix = "0.22.0"
+nix = "0.23"
 oci-spec = "0.5.0"
 openat = "0.1.20"
 openat-ext = "0.2.0"
 openssl = "0.10.33"
 ostree = { features = ["v2021_5"], version = "0.13.3" }
-phf = { features = ["macros"], version = "0.9.0" }
+phf = { features = ["macros"], version = "0.10" }
 pin-project = "1.0"
 serde = { features = ["derive"], version = "1.0.125" }
 serde_json = "1.0.64"


### PR DESCRIPTION
This refreshes `nix` and `phf` dependencies, making sure everything
is up-to-date.