### PR TITLE
 containers: Better handle errors from worker and/or driver

### DIFF
--- a/lib/src/container/deploy.rs
+++ b/lib/src/container/deploy.rs
@@ -3,6 +3,7 @@
 use super::OstreeImageReference;
 use crate::container::store::PrepareResult;
 use anyhow::Result;
+use fn_error_context::context;
 use ostree::glib;
 
 /// The key in the OSTree origin which holds a serialized [`super::OstreeImageReference`].
@@ -30,6 +31,7 @@ pub struct DeployOpts<'a> {
 /// Write a container image to an OSTree deployment.
 ///
 /// This API is currently intended for only an initial deployment.
+#[context("Performing deployment")]
 pub async fn deploy(
     sysroot: &ostree::Sysroot,
     stateroot: &str,


### PR DESCRIPTION


I was seeing this in a `cosa build`:

```
+ rpm-ostree ex-container image deploy --imgref ostree-unverified-image:oci-archive:/var/srv/walters/builds/rhcos-master/builds/410.84.202112092014-0-1/x86_64/rhcos-410.84.202112092014-0-ostree.x86_64.ociarchive --stateroot rhcos --sysroot /tmp/rootfs --karg=random.trust_cpu=on --karg=console=tty0 --karg=console=ttyS0,115200n8 --karg=ignition.platform.id=qemu '--karg=$ignition_firstboot'
error: Performing deployment: remote error: write |1: broken pipe
```
which is not useful.

This is really a brutal hack around the fact that an error can occur
on either our side or in the proxy.  But if an error occurs on our
side, then we will close the pipe, which will *also* cause the proxy
to error out.

What we really want is for the proxy to tell us when it got an
error from us closing the pipe.  Or, we could store that state
on our side.  Both are slightly tricky, so we have this (again)
hacky thing where we just search for `broken pipe` in the error text.

Or to restate all of the above - what this function does is check
to see if the worker function had an error *and* if the proxy
had an error, but if the proxy's error ends in `broken pipe`
then it means the real only error is from the worker.

Now:
```
+ rpm-ostree ex-container image deploy --imgref ostree-unverified-image:oci-archive:/var/srv/walters/builds/rhcos-master/builds/410.84.202112092014-0-1/x86_64/rhcos-410.84.202112092014-0-ostree.x86_64.ociarchive --stateroot rhcos --sysroot /tmp/rootfs --karg=random.trust_cpu=on --karg=console=tty0 --karg=console=ttyS0,115200n8 --karg=ignition.platform.id=qemu '--karg=$ignition_firstboot'
error: Performing deployment: Parsing blob sha256:9448e2c9ad473c7d63d7d7789eadd28e5ae72f37eb8a1c4901b7bd76764e9bd0: object 4f/5cc466c863110ecd782153cc3a126ba8593d531dde621539a2d1a290b6482b.file: Processing content object 4f5cc466c863110ecd782153cc3a126ba8593d531dde621539a2d1a290b6482b: Writing content object: Corrupted file object; checksum expected='4f5cc466c863110ecd782153cc3a126ba8593d531dde621539a2d1a290b6482b' actual='63e8321f6ed6f189d37d98d61e782e6e8c9031103c97c983c696de6ca42702f4'
```

(But why is that object corrupted?  Don't know yet,
 that's an exciting new problem!)