### PR TITLE
tar/export: Write symlink targets literally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ opt-level = 1 # No optimizations are too slow for us.
 
 [profile.release]
 lto = "thin"
+
+[patch.crates-io]
+tar = { path = "../../alexcrichton/tar-rs" }

--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -249,7 +249,7 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
                 h.set_size(0);
                 h.set_entry_type(tar::EntryType::Symlink);
                 let context = || format!("Writing content symlink: {}", checksum);
-                h.set_link_name(meta.symlink_target().unwrap().as_str())
+                h.set_link_name_literal(meta.symlink_target().unwrap().as_str())
                     .with_context(context)?;
                 self.out
                     .append_data(&mut h, &path, &mut std::io::empty())


### PR DESCRIPTION
Requires: https://github.com/alexcrichton/tar-rs/pull/274

And I'll just copy/paste the commit message from there, lightly edited:

In https://github.com/ostreedev/ostree we generate a cryptographic
checksum over files and symlinks, and directories.

ostree does not currently perform any canonicalization on symlinks;
we'll respect and honor whatever bytes we're provided as input,
and replicate that on the target.

We're using the Rust tar crate to do tar serialization,
which has so far worked fine...except, I hit this corner case:

```
[root@cosa-devsh ~]# rpm -qf /usr/lib/systemd/systemd-sysv-install
chkconfig-1.13-2.el8.x86_64
[root@cosa-devsh ~]# ll /usr/lib/systemd/systemd-sysv-install
lrwxrwxrwx. 2 root root 24 Nov 29 18:08 /usr/lib/systemd/systemd-sysv-install -> ../../..//sbin/chkconfig
[root@cosa-devsh ~]#
```

But, using `set_link_name` to write the tarball, we end up with
the canonicalized path `../../../sbin/chkconfig` - i.e. without the
double `//`.  This breaks the checksum.

Now, I am a bit tempted to change ostree to do canonicalization.  But
even if we did, I'd need to *exactly* match what tar-rs is doing.

(I may of course also try to change the rhel8 systemd package, but
 that's going to take a while to propagate and this corner case isn't
 the only one I'm sure)