### PR TITLE
container: Make layering more directly re-use unencapsulation

### DIFF
--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -275,6 +275,7 @@ impl LayeredImageImporter {
                 &self.repo,
                 &mut proxy,
                 target_imgref,
+                &self.proxy_img,
                 &import.manifest,
                 None,
                 true,


### PR DESCRIPTION
This came out of some prep work on
https://github.com/ostreedev/ostree-rs-ext/issues/69

Right now it's confusing, the layering code ended up re-implementing
the "fetch and unpack tarball" logic from the unencapsulation path
unnecessarily.

I think it's much clearer if the layering path just calls down
into the unencapsulation path first.

Among other things this will also ensure we're honoring the image
verification string.