### PR TITLE
lib/container: fix error prefix for invalid ostree imgref scheme

### DIFF
--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -182,7 +182,7 @@ impl TryFrom<&str> for OstreeImageReference {
                 (SignatureSource::OstreeRemote(remote.to_string()), second)
             }
             o => {
-                return Err(anyhow!("Invalid signature source: {}", o));
+                return Err(anyhow!("Invalid ostree image reference scheme: {}", o));
             }
         };
         let imgref = rest.deref().try_into()?;


### PR DESCRIPTION
This fixes a wrong and colliding error prefix, possibly coming
from a copy-paste mistake.