### PR TITLE
tar: Write directory hierarchy correctly

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -30,7 +30,8 @@ oci-spec = "0.5.0"
 openat = "0.1.20"
 openat-ext = "0.2.0"
 openssl = "0.10.33"
-ostree = { features = ["v2021_5"], version = "0.13.3" }
+# ostree = { features = ["v2021_5"], version = "0.13.3" }
+ostree = { git = "https://github.com/ostreedev/ostree-rs", features = ["v2021_5"] }
 phf = { features = ["macros"], version = "0.10" }
 pin-project = "1.0"
 serde = { features = ["derive"], version = "1.0.125" }


### PR DESCRIPTION


I hit on the fact that we were missing `/tmp` in the exported
container, and this is because we were actually missing writing
directory entries.  It only works because container runtimes
will auto-create parent directories.

But we clearly want to reflect the intended uid/gid/mode in the
tar stream too, and we definitely want empty toplevel dirs like
`/tmp`.

The simple fix of emitting them in our current flow actually fails
when trying to import into `containers/storage`, complaining about
duplicate entries.

And this is because the simple fix ends up writing a `sysroot` entry
with two different modes (0755 and 0700).  One or the other needs
to win, let's just have it be 0755 for now, though it doesn't really
matter for this.

So to really make this work, rework the flow so that the tar stream
looks like:

- root directory
- sysroot/ base structure
- commit object
- commit metadata
- contents of root recursively *except* sysroot

---

