### PR TITLE
Add new integration testing flow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,9 +31,14 @@ jobs:
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@ce325b60658c1b38465c06cc965b79baf32c1e72
       - name: Build
-        run: cargo test --no-run
+        run: cargo test --no-run && cargo build
       - name: Run tests
         run: cargo test -- --nocapture --quiet
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: ostree-ext-cli
+          path: target/debug/ostree-ext-cli
   build-minimum-toolchain:
     name: "Build, minimum supported toolchain (MSRV)"
     runs-on: ubuntu-latest
@@ -75,3 +80,19 @@ jobs:
         run: cargo fmt -- --check -l
       - name: cargo clippy (warnings)
         run: cargo clippy -- -D warnings
+  integration:
+    name: "Integration"
+    needs: build
+    runs-on: ubuntu-latest
+    container: quay.io/cgwalters/fcos
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Download ostree-ext-cli
+        uses: actions/download-artifact@v2
+        with:
+          name: ostree-ext-cli
+      - name: Install
+        run: install ostree-ext-cli /usr/bin && rm -v ostree-ext-cli
+      - name: Integration tests
+        run: ./ci/integration.sh

--- a/ci/integration.sh
+++ b/ci/integration.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Assumes that the current environment is a mutable ostree-container
+# with ostree-ext-cli installed in /usr/bin.  
+# Runs integration tests.
+set -xeuo pipefail
+
+# Output an ok message for TAP
+n_tap_tests=0
+tap_ok() {
+    echo "ok" "$@"
+    n_tap_tests=$(($n_tap_tests+1))
+}
+
+tap_end() {
+    echo "1..${n_tap_tests}"
+}
+
+env=$(ostree-ext-cli internal-only-for-testing detect-env)
+test "${env}" = ostree-container
+tap_ok environment
+
+tap_end

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -231,6 +231,13 @@ struct ImaSignOpts {
     key: String,
 }
 
+/// Options for internal testing
+#[derive(Debug, StructOpt)]
+enum TestingOpts {
+    // Detect the current environment
+    DetectEnv,
+}
+
 /// Toplevel options for extended ostree functionality.
 #[derive(Debug, StructOpt)]
 #[structopt(name = "ostree-ext")]
@@ -243,6 +250,8 @@ enum Opt {
     Container(ContainerOpts),
     /// IMA signatures
     ImaSign(ImaSignOpts),
+    #[structopt(setting(structopt::clap::AppSettings::Hidden))]
+    InternalOnlyForTesting(TestingOpts),
 }
 
 #[allow(clippy::from_over_into)]
@@ -437,6 +446,16 @@ fn ima_sign(cmdopts: &ImaSignOpts) -> Result<()> {
     Ok(())
 }
 
+fn testing(opts: &TestingOpts) -> Result<()> {
+    match opts {
+        TestingOpts::DetectEnv => {
+            let s = crate::integrationtest::detectenv();
+            println!("{}", s);
+            Ok(())
+        }
+    }
+}
+
 /// Parse the provided arguments and execute.
 /// Calls [`structopt::clap::Error::exit`] on failure, printing the error message and aborting the program.
 pub async fn run_from_iter<I>(args: I) -> Result<()>
@@ -525,5 +544,6 @@ where
             },
         },
         Opt::ImaSign(ref opts) => ima_sign(opts),
+        Opt::InternalOnlyForTesting(ref opts) => testing(opts),
     }
 }

--- a/lib/src/integrationtest.rs
+++ b/lib/src/integrationtest.rs
@@ -1,0 +1,14 @@
+//! Module used for integration tests; should not be public.
+
+fn has_ostree() -> bool {
+    std::path::Path::new("/sysroot/ostree/repo").exists()
+}
+
+pub(crate) fn detectenv() -> &'static str {
+    match (crate::container_utils::running_in_container(), has_ostree()) {
+        (true, true) => "ostree-container",
+        (true, false) => "container",
+        (false, true) => "ostree",
+        (false, false) => "none",
+    }
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -41,3 +41,5 @@ pub mod prelude {
     #[doc(hidden)]
     pub use ostree::prelude::*;
 }
+
+mod integrationtest;


### PR DESCRIPTION
The core idea here is that we take our built binary and inject
it into a fcos container image, where we can do further testing.

For now just to prove this out I've added an internal testutils
command.

(I think I'd like to write more tests in Rust, but to do that
 correctly we also want a `bin-unit-tests` feature like rpm-ostree
 has, which can come later)