### PR TITLE
Use a self-enabled `integration-testing-api` feature

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -47,9 +47,14 @@ tracing = "0.1"
 indoc = "1.0.3"
 quickcheck = "1"
 sh-inline = "0.1.0"
+# https://github.com/rust-lang/cargo/issues/2911
+# https://github.com/rust-lang/rfcs/pull/1956
+ostree-ext = { path = ".", features = ["internal-testing-api"] }
 
 [package.metadata.docs.rs]
 features = ["dox"]
 
 [features]
 dox = ["ostree/dox"]
+internal-testing-api = []
+

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -251,6 +251,7 @@ enum Opt {
     /// IMA signatures
     ImaSign(ImaSignOpts),
     #[structopt(setting(structopt::clap::AppSettings::Hidden))]
+    #[cfg(feature = "internal-testing-api")]
     InternalOnlyForTesting(TestingOpts),
 }
 
@@ -446,6 +447,7 @@ fn ima_sign(cmdopts: &ImaSignOpts) -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "internal-testing-api")]
 fn testing(opts: &TestingOpts) -> Result<()> {
     match opts {
         TestingOpts::DetectEnv => {
@@ -544,6 +546,7 @@ where
             },
         },
         Opt::ImaSign(ref opts) => ima_sign(opts),
+        #[cfg(feature = "internal-testing-api")]
         Opt::InternalOnlyForTesting(ref opts) => testing(opts),
     }
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -42,4 +42,5 @@ pub mod prelude {
     pub use ostree::prelude::*;
 }
 
+#[cfg(feature = "internal-testing-api")]
 mod integrationtest;


### PR DESCRIPTION
Most of our current testing is via an integration test,
which I designed after reading
https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html

However, I then wanted to use our internal OCI build tooling from the
integration test, which is blocked (by design) from seeing non-`pub`
things.

I initially tried doing:
```
#[cfg(test)]
pub fn do_oci_stuff(...)
```

but that didn't work.  (Perhaps it should?)

After some searching I came across this gem:
https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
Which, looks an amazing hack.  But it works.

The *big* downside of this is that now in order to properly test
building without the integration test feature, one must do so
via a fully distinct crate.