### PR TITLE
tar/export: Correctly set size and entry type for denormal links

### DIFF
--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -294,6 +294,8 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
                 let target = meta.symlink_target().unwrap();
                 let target = target.as_str();
                 let context = || format!("Writing content symlink: {}", checksum);
+                h.set_entry_type(tar::EntryType::Symlink);
+                h.set_size(0);
                 // Handle //chkconfig, see above
                 if symlink_is_denormal(target) {
                     h.set_link_name_literal(meta.symlink_target().unwrap().as_str())
@@ -302,8 +304,6 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
                         .append_data(&mut h, &path, &mut std::io::empty())
                         .with_context(context)?;
                 } else {
-                    h.set_entry_type(tar::EntryType::Symlink);
-                    h.set_size(0);
                     self.out
                         .append_link(&mut h, &path, target)
                         .with_context(context)?;


### PR DESCRIPTION
Fixes https://discussion.fedoraproject.org/t/rebasing-from-container-registry/35356

(This needs unit tests I know, but right now our content set is
 a manually-generated fixed tarball, and I have some patches in the
 work to improve the test suite)