### PR TITLE
tar: Move repo config into `/sysroot/config` by default for backcompat

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -55,6 +55,10 @@ struct ExportOpts {
     #[structopt(long)]
     repo: String,
 
+    /// The format version.  Must be 0 or 1.
+    #[structopt(long)]
+    format_version: u32,
+
     /// The ostree ref or commit to export
     rev: String,
 }
@@ -284,7 +288,12 @@ async fn tar_import(opts: &ImportOpts) -> Result<()> {
 /// Export a tar archive containing an ostree commit.
 fn tar_export(opts: &ExportOpts) -> Result<()> {
     let repo = &ostree::Repo::open_at(libc::AT_FDCWD, opts.repo.as_str(), gio::NONE_CANCELLABLE)?;
-    crate::tar::export_commit(repo, opts.rev.as_str(), std::io::stdout())?;
+    #[allow(clippy::needless_update)]
+    let subopts = crate::tar::ExportOptions {
+        format_version: opts.format_version,
+        ..Default::default()
+    };
+    crate::tar::export_commit(repo, opts.rev.as_str(), std::io::stdout(), Some(subopts))?;
     Ok(())
 }
 

--- a/lib/src/container/encapsulate.rs
+++ b/lib/src/container/encapsulate.rs
@@ -36,7 +36,7 @@ fn export_ostree_ref(
 ) -> Result<ociwriter::Layer> {
     let commit = repo.resolve_rev(rev, false)?.unwrap();
     let mut w = writer.create_raw_layer(compression)?;
-    ostree_tar::export_commit(repo, commit.as_str(), &mut w)?;
+    ostree_tar::export_commit(repo, commit.as_str(), &mut w, None)?;
     w.complete()
 }
 


### PR DESCRIPTION
It turns out adding `/sysroot/ostree/repo/config` into the export
stream broke compat with older code.  Now in theory this is all
experimental and changeable, but it breaks the FCOS upgrade testing
because the export format there is "production" for some values of
production.

And for our own sanity, it's helpful to be compatible.
And add format versioning into the tar export code, and default to v0
where we put the config into `/sysroot/config` where it will be ignored
by older ostree.

This in particular should allow us to update rpm-ostree to the
latest ostree-ext in https://github.com/coreos/rpm-ostree/pull/3285