### PR TITLE
lib/src/cli: Update BuildOpts fields to denote they might not be read

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -25,18 +25,6 @@ fn parse_base_imgref(s: &str) -> Result<ImageReference> {
     ImageReference::try_from(s)
 }
 
-#[derive(Debug, StructOpt)]
-struct BuildOpts {
-    #[structopt(long)]
-    repo: String,
-
-    #[structopt(long = "ref")]
-    ostree_ref: String,
-
-    #[structopt(long)]
-    oci_dir: String,
-}
-
 /// Options for importing a tar archive.
 #[derive(Debug, StructOpt)]
 struct ImportOpts {


### PR DESCRIPTION
This fixes the above warning:
```
cargo build
   Compiling ostree-ext v0.5.1 (/var/home/jmarrero/Development/github/ostreedev/ostree-rs-ext/lib)
warning: field is never read: `repo`
  --> lib/src/cli.rs:31:5
   |
31 |     repo: String,
   |     ^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: field is never read: `ostree_ref`
  --> lib/src/cli.rs:34:5
   |
34 |     ostree_ref: String,
   |     ^^^^^^^^^^^^^^^^^^

warning: field is never read: `oci_dir`
  --> lib/src/cli.rs:37:5
   |
37 |     oci_dir: String,
   |     ^^^^^^^^^^^^^^^

warning: `ostree-ext` (lib) generated 3 warnings
```

Also making the struct and fields pub will fix it but since the other struct in the module are not pub I am just adding the underscore here.