### PR TITLE
lib: Switch to released containers-image-proxy version

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -10,8 +10,7 @@ version = "0.5.1"
 
 [dependencies]
 anyhow = "1.0"
-# containers-image-proxy = "0.3"
-containers-image-proxy = { git = "https://github.com/containers/containers-image-proxy-rs" }
+containers-image-proxy = "0.4.0"
 
 async-compression = { version = "0.3", features = ["gzip", "tokio"] }
 bitflags = "1"
@@ -57,4 +56,4 @@ features = ["dox"]
 [features]
 dox = ["ostree/dox"]
 internal-testing-api = []
-
+proxy_v0_2_3 = ["containers-image-proxy/proxy_v0_2_3"]

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -546,19 +546,16 @@ async fn test_container_write_derive() -> Result<()> {
     assert!(digest.starts_with("sha256:"));
     assert_eq!(digest, expected_digest);
 
-    // For now we need to make this test dynamic
+    #[cfg(feature = "proxy_v0_2_3")]
     {
+        let commit_meta = &imported_commit.child_value(0);
         let proxy = containers_image_proxy::ImageProxy::new().await?;
-        let proxy = proxy.get_0_2_3();
-        if proxy.is_some() {
-            let commit_meta = &imported_commit.child_value(0);
-            let commit_meta = glib::VariantDict::new(Some(commit_meta));
-            let config = commit_meta
-                .lookup::<String>("ostree.container.image-config")?
-                .unwrap();
-            let config: oci_spec::image::ImageConfiguration = serde_json::from_str(&config)?;
-            assert_eq!(config.os(), &oci_spec::image::Os::Linux);
-        }
+        let commit_meta = glib::VariantDict::new(Some(commit_meta));
+        let config = commit_meta
+            .lookup::<String>("ostree.container.image-config")?
+            .unwrap();
+        let config: oci_spec::image::ImageConfiguration = serde_json::from_str(&config)?;
+        assert_eq!(config.os(), &oci_spec::image::Os::Linux);
     }
 
     // Parse the commit and verify we pulled the derived content.


### PR DESCRIPTION
We cut a new version upstream, let's switch back to crate dependencies.