### PR TITLE
Release 0.6.0

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -29,8 +29,7 @@ oci-spec = "0.5.0"
 openat = "0.1.20"
 openat-ext = "0.2.0"
 openssl = "0.10.33"
-# ostree = { features = ["v2021_5"], version = "0.13.3" }
-ostree = { git = "https://github.com/ostreedev/ostree-rs", features = ["v2021_5"] }
+ostree = { features = ["v2021_5"], version = "0.13.4" }
 phf = { features = ["macros"], version = "0.10" }
 pin-project = "1.0"
 serde = { features = ["derive"], version = "1.0.125" }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
-version = "0.5.1"
+version = "0.6.0"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Switch to published ostree crate

In prep for releasing a new version.

---

Release 0.6.0

Semver bump because of various API changes.

---

