### PR TITLE
ocidir: Add creation time into history

### DIFF
--- a/lib/src/container/ocidir.rs
+++ b/lib/src/container/ocidir.rs
@@ -238,7 +238,18 @@ impl OciDir {
             format!("sha256:{}", layer.uncompressed_sha256),
         ));
         config.set_rootfs(rootfs);
+        // There is e.g. https://docs.rs/chrono/latest/chrono/struct.DateTime.html#method.to_rfc3339_opts
+        // and chrono is already in our dependency chain, just indirectly because of tracing-subscriber.
+        // glib actually also has https://docs.rs/glib/latest/glib/struct.DateTime.html#method.format_iso8601
+        // but that requires a newer glib.
+        // Since glib is going to be required by ostree for the forseeable future, for now
+        // let's use that instead of adding chrono.
+        let now = ostree::glib::DateTime::new_now_utc()
+            .unwrap()
+            .format("%Y-%m-%dT%H:%M:%S.%fZ")
+            .unwrap();
         let h = oci_image::HistoryBuilder::default()
+            .created(now)
             .created_by(description.to_string())
             .build()
             .unwrap();


### PR DESCRIPTION
Turns out that `podman history` segfaults if this is missing.

Closes: https://github.com/ostreedev/ostree-rs-ext/issues/211