### PR TITLE
container: Support `/etc/ostree/auth.json` and in `/run` too

### DIFF
--- a/ci/integration.sh
+++ b/ci/integration.sh
@@ -19,4 +19,7 @@ env=$(ostree-ext-cli internal-only-for-testing detect-env)
 test "${env}" = ostree-container
 tap_ok environment
 
+ostree-ext-cli internal-only-for-testing run
+tap_ok integrationtests
+
 tap_end

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -126,6 +126,10 @@ enum ContainerOpts {
 #[derive(Debug, StructOpt)]
 struct ContainerProxyOpts {
     #[structopt(long)]
+    /// Do not use default authentication files.
+    auth_anonymous: bool,
+
+    #[structopt(long)]
     /// Path to Docker-formatted authentication file.
     authfile: Option<PathBuf>,
 
@@ -232,6 +236,8 @@ struct ImaSignOpts {
 enum TestingOpts {
     // Detect the current environment
     DetectEnv,
+    /// Execute integration tests, assuming mutable environment
+    Run,
 }
 
 /// Toplevel options for extended ostree functionality.
@@ -255,6 +261,7 @@ enum Opt {
 impl Into<ostree_container::store::ImageProxyConfig> for ContainerProxyOpts {
     fn into(self) -> ostree_container::store::ImageProxyConfig {
         ostree_container::store::ImageProxyConfig {
+            auth_anonymous: self.auth_anonymous,
             authfile: self.authfile,
             certificate_directory: self.cert_dir,
             insecure_skip_tls_verification: Some(self.insecure_skip_tls_verification),
@@ -456,6 +463,7 @@ fn testing(opts: &TestingOpts) -> Result<()> {
             println!("{}", s);
             Ok(())
         }
+        TestingOpts::Run => crate::integrationtest::run_tests(),
     }
 }
 

--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -213,6 +213,17 @@ impl std::fmt::Display for OstreeImageReference {
     }
 }
 
+/// Apply default configuration for container image pulls to an existing configuration.
+/// For example, if `authfile` is not set, and `auth_anonymous` is `false`, and a global configuration file exists, it will be used.
+pub fn merge_default_container_proxy_opts(
+    config: &mut containers_image_proxy::ImageProxyConfig,
+) -> Result<()> {
+    if !config.auth_anonymous && config.authfile.is_none() {
+        config.authfile = crate::globals::get_global_authfile_path()?;
+    }
+    Ok(())
+}
+
 pub mod deploy;
 mod encapsulate;
 pub use encapsulate::*;

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -182,8 +182,10 @@ impl LayeredImageImporter {
     pub async fn new(
         repo: &ostree::Repo,
         imgref: &OstreeImageReference,
-        config: ImageProxyConfig,
+        mut config: ImageProxyConfig,
     ) -> Result<Self> {
+        // Apply our defaults to the proxy config
+        merge_default_container_proxy_opts(&mut config)?;
         let proxy = ImageProxy::new_with_config(config).await?;
         let proxy_img = proxy.open_image(&imgref.imgref.to_string()).await?;
         let repo = repo.clone();

--- a/lib/src/container_utils.rs
+++ b/lib/src/container_utils.rs
@@ -30,7 +30,7 @@ pub fn running_in_container() -> bool {
 
 // https://docs.rs/openat-ext/0.1.10/openat_ext/trait.OpenatDirExt.html#tymethod.open_file_optional
 // https://users.rust-lang.org/t/why-i-use-anyhow-error-even-in-libraries/68592
-fn open_optional(path: impl AsRef<Path>) -> std::io::Result<Option<std::fs::File>> {
+pub(crate) fn open_optional(path: impl AsRef<Path>) -> std::io::Result<Option<std::fs::File>> {
     match std::fs::File::open(path.as_ref()) {
         Ok(r) => Ok(Some(r)),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),

--- a/lib/src/globals.rs
+++ b/lib/src/globals.rs
@@ -1,0 +1,62 @@
+//! Global functions.
+
+use super::Result;
+use once_cell::sync::OnceCell;
+use ostree::glib;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+struct ConfigPaths {
+    persistent: PathBuf,
+    runtime: PathBuf,
+}
+
+/// Get the runtime and persistent config directories.  In the system (root) case, these
+/// system(root) case:  /run/ostree           /etc/ostree
+/// user(nonroot) case: /run/user/$uid/ostree ~/.config/ostree
+fn get_config_paths() -> &'static ConfigPaths {
+    static PATHS: OnceCell<ConfigPaths> = OnceCell::new();
+    PATHS.get_or_init(|| {
+        let mut r = if rustix::process::getuid() == rustix::process::Uid::ROOT {
+            ConfigPaths {
+                persistent: PathBuf::from("/etc"),
+                runtime: PathBuf::from("/run"),
+            }
+        } else {
+            ConfigPaths {
+                persistent: glib::user_config_dir(),
+                runtime: glib::user_runtime_dir(),
+            }
+        };
+        let path = "ostree";
+        r.persistent.push(path);
+        r.runtime.push(path);
+        r
+    })
+}
+
+impl ConfigPaths {
+    /// Return the path and an open fd for a config file, if it exists.
+    pub(crate) fn open_file(&self, p: impl AsRef<Path>) -> Result<Option<(PathBuf, File)>> {
+        let p = p.as_ref();
+        let mut runtime = self.runtime.clone();
+        runtime.push(p);
+        if let Some(f) = crate::container_utils::open_optional(&runtime)? {
+            return Ok(Some((runtime, f)));
+        }
+        let mut persistent = self.persistent.clone();
+        persistent.push(p);
+        if let Some(f) = crate::container_utils::open_optional(&persistent)? {
+            return Ok(Some((persistent, f)));
+        }
+        Ok(None)
+    }
+}
+
+/// Return the path to the global container authentication file, if it exists.
+pub(crate) fn get_global_authfile_path() -> Result<Option<PathBuf>> {
+    let paths = get_config_paths();
+    let r = paths.open_file("auth.json")?;
+    // TODO pass the file descriptor to the proxy, not a global path
+    Ok(r.map(|v| v.0))
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -23,6 +23,9 @@ pub use ostree::gio::glib;
 /// to a string to output to a terminal or logs.
 type Result<T> = anyhow::Result<T>;
 
+// Import global functions.
+mod globals;
+
 pub mod cli;
 pub mod container;
 pub mod container_utils;


### PR DESCRIPTION
This is related to https://github.com/ostreedev/ostree-rs-ext/issues/121
as well as https://github.com/containers/containers-image-proxy-rs/pull/8
etc.

The CLI code here supports `--authfile`.  However, passing it on
the CLI each time for production use cases pushes complexity to
users.

Add support for global persistent and runtime config files in
`/etc/ostree/auth.json` and `/run/ostree/auth.json`.

Change the default constructor for image pulls to use that by default.

Note that the CLI options override the config defaults.

While we're here, also add `--auth-anonymous` to the CLI, which is
needed to ensure we don't use a config file if present.