### PR TITLE
Use new correct `impl Default` for oci bits

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -32,7 +32,6 @@ openat = "0.1.20"
 openat-ext = "0.2.0"
 openssl = "0.10.33"
 ostree = { features = ["v2021_5"], version = "0.13.4" }
-phf = { features = ["macros"], version = "0.10" }
 pin-project = "1.0"
 serde = { features = ["derive"], version = "1.0.125" }
 serde_json = "1.0.64"

--- a/lib/src/container/encapsulate.rs
+++ b/lib/src/container/encapsulate.rs
@@ -74,7 +74,7 @@ fn build_oci(
     let commit_meta = glib::VariantDict::new(Some(commit_meta));
 
     let mut ctrcfg = oci_image::Config::default();
-    let mut imgcfg = ocidir::new_config_thisarch_linux();
+    let mut imgcfg = oci_image::ImageConfiguration::default();
     let labels = ctrcfg.labels_mut().get_or_insert_with(Default::default);
     let mut manifest = ocidir::new_empty_manifest().build().unwrap();
 
@@ -119,7 +119,7 @@ fn build_oci(
     );
     let ctrcfg = writer.write_config(imgcfg)?;
     manifest.set_config(ctrcfg);
-    writer.write_manifest(manifest, ocidir::this_platform())?;
+    writer.write_manifest(manifest, oci_image::Platform::default())?;
 
     Ok(ImageReference {
         transport: Transport::OciDir,

--- a/lib/src/integrationtest.rs
+++ b/lib/src/integrationtest.rs
@@ -6,6 +6,7 @@ use crate::container::ocidir;
 use anyhow::Result;
 use camino::Utf8Path;
 use fn_error_context::context;
+use oci_spec::image as oci_image;
 
 fn has_ostree() -> bool {
     std::path::Path::new("/sysroot/ostree/repo").exists()
@@ -60,7 +61,7 @@ pub fn generate_derived_oci(src: impl AsRef<Utf8Path>, dir: impl AsRef<Utf8Path>
     let new_config_desc = src.write_config(config)?;
     manifest.set_config(new_config_desc);
 
-    src.write_manifest(manifest, ocidir::this_platform())?;
+    src.write_manifest(manifest, oci_image::Platform::default())?;
     Ok(())
 }
 


### PR DESCRIPTION
Now that https://github.com/containers/oci-spec-rs/pull/90/commits/6e65562e3d70b66656598e6a567dc71e80dd0f56
landed, we can just depend on it and not have a hardcoded
architecture mapping here.