### PR TITLE
Add and use an API to require being in an ostree container

### DIFF
--- a/lib/src/container_utils.rs
+++ b/lib/src/container_utils.rs
@@ -68,3 +68,13 @@ pub fn is_bare_split_xattrs() -> Result<bool> {
 pub fn is_ostree_container() -> Result<bool> {
     Ok(running_in_container() && is_bare_split_xattrs()?)
 }
+
+/// Returns an error unless the current filesystem is an ostree-based container
+///
+/// This just wraps [`is_ostree_container`].
+pub fn require_ostree_container() -> Result<()> {
+    if !is_ostree_container()? {
+        anyhow::bail!("Not in an ostree-based container environment");
+    }
+    Ok(())
+}

--- a/lib/src/integrationtest.rs
+++ b/lib/src/integrationtest.rs
@@ -91,6 +91,7 @@ fn test_proxy_auth() -> Result<()> {
 #[cfg(feature = "internal-testing-api")]
 #[context("Running integration tests")]
 pub(crate) fn run_tests() -> Result<()> {
+    crate::container_utils::require_ostree_container()?;
     // When there's a new integration test to run, add it here.
     test_proxy_auth()?;
     println!("integration tests succeeded.");


### PR DESCRIPTION
utils: Add an API to require being in an ostree container

Most of our callers actually want this.

---

lib/commit: Use `require_ostree_container()` API

---

