### PR TITLE
Switch to new `require_rev` API

### DIFF
--- a/lib/src/container/encapsulate.rs
+++ b/lib/src/container/encapsulate.rs
@@ -40,7 +40,7 @@ fn export_ostree_ref(
     writer: &mut OciDir,
     compression: Option<flate2::Compression>,
 ) -> Result<ocidir::Layer> {
-    let commit = repo.resolve_rev(rev, false)?.unwrap();
+    let commit = repo.require_rev(rev)?;
     let mut w = writer.create_raw_layer(compression)?;
     ostree_tar::export_commit(repo, commit.as_str(), &mut w, None)?;
     w.complete()
@@ -60,7 +60,7 @@ fn build_oci(
     let ocidir = Rc::new(openat::Dir::open(ocidir_path)?);
     let mut writer = ocidir::OciDir::create(ocidir)?;
 
-    let commit = repo.resolve_rev(rev, false)?.unwrap();
+    let commit = repo.require_rev(rev)?;
     let commit = commit.as_str();
     let (commit_v, _) = repo.load_commit(commit)?;
     let commit_subject = commit_v.child_value(3);

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -469,7 +469,7 @@ pub async fn copy(
     imgref: &OstreeImageReference,
 ) -> Result<()> {
     let ostree_ref = ref_for_image(&imgref.imgref)?;
-    let rev = src_repo.resolve_rev(&ostree_ref, false)?.unwrap();
+    let rev = src_repo.require_rev(&ostree_ref)?;
     let (commit_obj, _) = src_repo.load_commit(rev.as_str())?;
     let commit_meta = &glib::VariantDict::new(Some(&commit_obj.child_value(0)));
     let (manifest, _) = manifest_data_from_commitmeta(commit_meta)?;

--- a/lib/src/ima.rs
+++ b/lib/src/ima.rs
@@ -271,7 +271,7 @@ impl<'a> CommitRewriter<'a> {
     /// Write a commit object.
     #[context("Mapping {}", rev)]
     fn map_commit(&mut self, rev: &str) -> Result<String> {
-        let checksum = self.repo.resolve_rev(rev, false)?.unwrap();
+        let checksum = self.repo.require_rev(rev)?;
         let cancellable = gio::NONE_CANCELLABLE;
         let (commit_v, _) = self.repo.load_commit(&checksum)?;
         let commit_v = &commit_v;

--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -423,10 +423,10 @@ pub fn export_commit(
     out: impl std::io::Write,
     options: Option<ExportOptions>,
 ) -> Result<()> {
-    let commit = repo.resolve_rev(rev, false)?;
+    let commit = repo.require_rev(rev)?;
     let mut tar = tar::Builder::new(out);
     let options = options.unwrap_or_default();
-    impl_export(repo, commit.unwrap().as_str(), &mut tar, options)?;
+    impl_export(repo, commit.as_str(), &mut tar, options)?;
     tar.finish()?;
     Ok(())
 }

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -390,9 +390,8 @@ async fn test_container_import_export() -> Result<()> {
     let fixture = Fixture::new()?;
     let testrev = fixture
         .srcrepo
-        .resolve_rev(TESTREF, false)
-        .context("Failed to resolve ref")?
-        .unwrap();
+        .require_rev(TESTREF)
+        .context("Failed to resolve ref")?;
 
     let srcoci_path = &fixture.path.join("oci");
     let srcoci_imgref = ImageReference {
@@ -707,9 +706,8 @@ async fn test_container_import_export_registry() -> Result<()> {
     let fixture = Fixture::new()?;
     let testrev = fixture
         .srcrepo
-        .resolve_rev(TESTREF, false)
-        .context("Failed to resolve ref")?
-        .unwrap();
+        .require_rev(TESTREF)
+        .context("Failed to resolve ref")?;
     let src_imgref = ImageReference {
         transport: Transport::Registry,
         name: format!("{}/exampleos", tr),


### PR DESCRIPTION
I added this back in
https://github.com/ostreedev/ostree-rs/pull/35/commits/f8aa658d17af9c13702a20ea8d4030cc34121bc8
and only recently remembered about it when modifying some other
code.

We need some sort of automatic reminder system for "remember
to use this new API from your dependency".