### PR TITLE
tar: revert to previous mode bits, fix importing

### DIFF
--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -281,7 +281,7 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
         h.set_uid(meta.attribute_uint32("unix::uid") as u64);
         h.set_gid(meta.attribute_uint32("unix::gid") as u64);
         let mode = meta.attribute_uint32("unix::mode");
-        h.set_mode(mode & !libc::S_IFMT);
+        h.set_mode(mode);
         let mut target_header = h.clone();
         target_header.set_size(0);
 
@@ -335,7 +335,7 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
         header.set_size(0);
         header.set_uid(meta.uid as u64);
         header.set_gid(meta.gid as u64);
-        header.set_mode(meta.mode & !libc::S_IFMT);
+        header.set_mode(meta.mode);
         self.out
             .append_data(&mut header, dirpath, std::io::empty())?;
         Ok(())

--- a/lib/src/tar/import.rs
+++ b/lib/src/tar/import.rs
@@ -266,7 +266,7 @@ impl Importer {
             Some(checksum),
             uid,
             gid,
-            libc::S_IFREG | mode,
+            mode,
             xattrs.as_ref(),
             &buf,
             cancellable,

--- a/lib/src/tar/import.rs
+++ b/lib/src/tar/import.rs
@@ -266,7 +266,7 @@ impl Importer {
             Some(checksum),
             uid,
             gid,
-            mode,
+            libc::S_IFREG | mode,
             xattrs.as_ref(),
             &buf,
             cancellable,

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -269,7 +269,15 @@ fn validate_tar_expected<T: std::io::Read>(
         let entry_path = entry.path().unwrap().to_string_lossy().into_owned();
         if let Some(exp) = expected.remove(entry_path.as_str()) {
             assert_eq!(header.entry_type(), exp.etype, "{}", entry_path);
-            assert_eq!(header.mode().unwrap(), exp.mode, "{}", entry_path);
+            // FIXME: change the generation code to not inject the format bits into the mode,
+            // because tar doesn't need/use it.
+            // https://github.com/ostreedev/ostree-rs-ext/pull/217/files#r791942496
+            assert_eq!(
+                header.mode().unwrap() & !libc::S_IFMT,
+                exp.mode,
+                "{}",
+                entry_path
+            );
         }
     }
 
@@ -295,7 +303,7 @@ fn test_tar_export_structure() -> Result<()> {
     let first = entries.next().unwrap()?;
     let firstpath = first.path()?;
     assert_eq!(firstpath.to_str().unwrap(), "./");
-    assert_eq!(first.header().mode()?, 0o755);
+    assert_eq!(first.header().mode()?, libc::S_IFDIR | 0o755);
     let next = entries.next().unwrap().unwrap();
     assert_eq!(next.path().unwrap().as_os_str(), "sysroot");
 


### PR DESCRIPTION
This reverts https://github.com/ostreedev/ostree-rs-ext/pull/220.
But it keeps a patch which should be fixing the underlying import bug.
