### PR TITLE
lib/container: Quiet dead code warnings for `ocidir`

### DIFF
--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -229,6 +229,15 @@ mod encapsulate;
 pub use encapsulate::*;
 mod unencapsulate;
 pub use unencapsulate::*;
+// We have this trick of compiling ourself with integration testing
+// enabled, which uses a lot of the code here.   See the
+// `ostree-ext = { path = ".", features = ["internal-testing-api"] }`
+// bit in Cargo.toml.
+//
+// But that isn't turned on for other crates that use this, and correctly gating all
+// of it is a little tedious.  So let's just use the big hammer for now to
+// quiet the dead code warnings.
+#[allow(dead_code)]
 pub(crate) mod ocidir;
 mod skopeo;
 pub mod store;

--- a/lib/src/container/ocidir.rs
+++ b/lib/src/container/ocidir.rs
@@ -133,7 +133,6 @@ impl OciDir {
         Self::open(dir)
     }
 
-    #[allow(dead_code)]
     /// Clone an OCI directory, using reflinks for blobs.
     pub(crate) fn clone_to(&self, destdir: &openat::Dir, p: impl AsRef<Path>) -> Result<Self> {
         let p = p.as_ref();
@@ -160,7 +159,6 @@ impl OciDir {
         RawLayerWriter::new(&self.dir, c)
     }
 
-    #[allow(dead_code)]
     /// Create a tar output stream, backed by a blob
     pub(crate) fn create_layer(
         &self,
@@ -170,7 +168,7 @@ impl OciDir {
     }
 
     /// Add a layer to the top of the image stack.  The firsh pushed layer becomes the root.
-    #[allow(dead_code)]
+
     pub(crate) fn push_layer(
         &self,
         manifest: &mut oci_image::ImageManifest,


### PR DESCRIPTION
We have this trick of compiling ourself with integration testing
enabled, which uses a lot of the code here.   See the
`ostree-ext = { path = ".", features = ["internal-testing-api"] }`
bit in Cargo.toml.

But that isn't turned on for other crates that use this, and correctly gating all
of it is a little tedious.  So let's just use the big hammer for now to
quiet the dead code warnings.