### PR TITLE
Release 0.6.2

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
-version = "0.6.1"
+version = "0.6.2"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Fixes a backwards incompatible change in the (now yanked) 0.6.1.