### PR TITLE
ocidir: Use `chrono`, not `glib` for time formatting

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -15,6 +15,7 @@ containers-image-proxy = "0.4.0"
 async-compression = { version = "0.3", features = ["gzip", "tokio"] }
 bitflags = "1"
 camino = "1.0.4"
+chrono = "0.4.19"
 cjson = "0.1.1"
 cap-std-ext = "0.24"
 flate2 = { features = ["zlib"], default_features = false, version = "1.0.20" }

--- a/lib/src/container/ocidir.rs
+++ b/lib/src/container/ocidir.rs
@@ -203,18 +203,9 @@ impl OciDir {
             format!("sha256:{}", layer.uncompressed_sha256),
         ));
         config.set_rootfs(rootfs);
-        // There is e.g. https://docs.rs/chrono/latest/chrono/struct.DateTime.html#method.to_rfc3339_opts
-        // and chrono is already in our dependency chain, just indirectly because of tracing-subscriber.
-        // glib actually also has https://docs.rs/glib/latest/glib/struct.DateTime.html#method.format_iso8601
-        // but that requires a newer glib.
-        // Since glib is going to be required by ostree for the forseeable future, for now
-        // let's use that instead of adding chrono.
-        let now = ostree::glib::DateTime::new_now_utc()
-            .unwrap()
-            .format("%Y-%m-%dT%H:%M:%S.%fZ")
-            .unwrap();
+        let now = chrono::offset::Utc::now();
         let h = oci_image::HistoryBuilder::default()
-            .created(now)
+            .created(now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
             .created_by(description.to_string())
             .build()
             .unwrap();


### PR DESCRIPTION
Sadly RHEL8's glib is too old for this.  Switch to using chrono.