### PR TITLE
Release 0.6.3

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
-version = "0.6.2"
+version = "0.6.3"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Nothing critical, just the cap-std bump and the chrono fix;
I particularly want the latter for the next rpm-ostree.