### PR TITLE
container/encapsulate: Honor `ostree.container-cmd`

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -31,7 +31,7 @@ oci-spec = "0.5.4"
 openat = "0.1.20"
 openat-ext = "0.2.0"
 openssl = "0.10.33"
-ostree = { features = ["v2021_5"], version = "0.13.4" }
+ostree = { features = ["v2021_5", "cap-std-apis"], version = "0.13.5" }
 pin-project = "1.0"
 serde = { features = ["derive"], version = "1.0.125" }
 serde_json = "1.0.64"

--- a/lib/src/container/encapsulate.rs
+++ b/lib/src/container/encapsulate.rs
@@ -121,7 +121,11 @@ fn build_oci(
     for (k, v) in config.labels.iter().map(|k| k.iter()).flatten() {
         labels.insert(k.into(), v.into());
     }
-    if let Some(cmd) = config.cmd.as_ref() {
+    // Lookup the cmd embedded in commit metadata
+    let cmd = commit_meta.lookup::<Vec<String>>(ostree::COMMIT_META_CONTAINER_CMD)?;
+    // But support it being overridden by CLI options
+    let cmd = config.cmd.as_ref().or_else(|| cmd.as_ref());
+    if let Some(cmd) = cmd {
         ctrcfg.set_cmd(Some(cmd.clone()));
     }
 


### PR DESCRIPTION
lib: Bump ostree crate, enable `cap-std-apis`

This way we can start making use of cap-std more.

---

container/encapsulate: Honor `ostree.container-cmd`

Builds on https://github.com/ostreedev/ostree-rs/pull/47/commits/6d3a69cc43214a77085e98f062f9f624c4ea25db

Part of https://github.com/coreos/coreos-assembler/issues/2685

---

