### PR TITLE
cli: Drop use of `select`

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -40,6 +40,7 @@ tar = "0.4.38"
 tempfile = "3.2.0"
 tokio = { features = ["full"], version = "1" }
 tokio-util = { features = ["io-util"], version = "0.6.9" }
+tokio-stream = { features = ["sync"], version = "0.1.8" }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/lib/src/tokio_util.rs
+++ b/lib/src/tokio_util.rs
@@ -16,6 +16,8 @@ where
     let notify2 = notify.clone();
     cancellable.connect_cancelled(move |_| notify2.notify_one());
     cancellable.set_error_if_cancelled()?;
+    // See https://blog.yoshuawuyts.com/futures-concurrency-3/ on why
+    // `select!` is a trap in general, but I believe this case is safe.
     tokio::select! {
        r = f => r,
        _ = notify.notified() => {


### PR DESCRIPTION
I saw https://blog.yoshuawuyts.com/futures-concurrency-3/
go by and decided to audit our use of `select!` - I am definitely
not an expert but my understanding is the CLI use case is buggy,
but the other one is not.

Rewrite the CLI case to operate on an explicit stream of values.