### PR TITLE
tar/export: export empty xattrs in v1 format

### DIFF
--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -296,7 +296,7 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
     fn append_xattrs(&mut self, checksum: &str, xattrs: &glib::Variant) -> Result<bool> {
         let xattrs_data = xattrs.data_as_bytes();
         let xattrs_data = xattrs_data.as_ref();
-        if xattrs_data.is_empty() {
+        if xattrs_data.is_empty() && self.options.format_version == 0 {
             return Ok(false);
         }
 


### PR DESCRIPTION
This makes sure that xattrs content is always exported in v1 format,
even the empty attributes set. Previous behaviour is retained for v0,
for compatibility.