### PR TITLE
tests: Factor out test fixture as a separate module

### DIFF
--- a/lib/tests/it/fixture.rs
+++ b/lib/tests/it/fixture.rs
@@ -1,0 +1,107 @@
+use anyhow::Result;
+use camino::{Utf8Path, Utf8PathBuf};
+use fn_error_context::context;
+use indoc::indoc;
+use ostree_ext::gio;
+use sh_inline::bash;
+use std::convert::TryInto;
+
+const OSTREE_GPG_HOME: &[u8] = include_bytes!("fixtures/ostree-gpg-test-home.tar.gz");
+const TEST_GPG_KEYID_1: &str = "7FCA23D8472CDAFA";
+#[allow(dead_code)]
+const TEST_GPG_KEYFPR_1: &str = "5E65DE75AB1C501862D476347FCA23D8472CDAFA";
+pub(crate) const EXAMPLEOS_V0: &[u8] = include_bytes!("fixtures/exampleos.tar.zst");
+pub(crate) const EXAMPLEOS_V1: &[u8] = include_bytes!("fixtures/exampleos-v1.tar.zst");
+const TESTREF: &str = "exampleos/x86_64/stable";
+
+pub(crate) struct Fixture {
+    // Just holds a reference
+    _tempdir: tempfile::TempDir,
+    pub(crate) path: Utf8PathBuf,
+    pub(crate) srcdir: Utf8PathBuf,
+    pub(crate) srcrepo: ostree::Repo,
+    pub(crate) destrepo: ostree::Repo,
+    pub(crate) destrepo_path: Utf8PathBuf,
+
+    pub(crate) format_version: u32,
+}
+
+impl Fixture {
+    pub(crate) fn new() -> Result<Self> {
+        let _tempdir = tempfile::tempdir_in("/var/tmp")?;
+        let path: &Utf8Path = _tempdir.path().try_into().unwrap();
+        let path = path.to_path_buf();
+
+        let srcdir = path.join("src");
+        std::fs::create_dir(&srcdir)?;
+        let srcrepo_path = generate_test_repo(&srcdir, TESTREF)?;
+        let srcrepo =
+            ostree::Repo::open_at(libc::AT_FDCWD, srcrepo_path.as_str(), gio::NONE_CANCELLABLE)?;
+
+        let destdir = &path.join("dest");
+        std::fs::create_dir(destdir)?;
+        let destrepo_path = destdir.join("repo");
+        let destrepo = ostree::Repo::new_for_path(&destrepo_path);
+        destrepo.create(ostree::RepoMode::BareUser, gio::NONE_CANCELLABLE)?;
+        Ok(Self {
+            _tempdir,
+            path,
+            srcdir,
+            srcrepo,
+            destrepo,
+            destrepo_path,
+            format_version: 0,
+        })
+    }
+
+    pub(crate) fn testref(&self) -> &'static str {
+        TESTREF
+    }
+
+    pub(crate) fn update(&mut self) -> Result<()> {
+        let repopath = &self.srcdir.join("repo");
+        let repotmp = &repopath.join("tmp");
+        let srcpath = &repotmp.join("exampleos-v1.tar.zst");
+        std::fs::write(srcpath, EXAMPLEOS_V1)?;
+        let srcpath = srcpath.as_str();
+        let repopath = repopath.as_str();
+        let testref = TESTREF;
+        bash!(
+            "ostree --repo={repopath} commit -b {testref} --no-bindings --tree=tar={srcpath}",
+            testref,
+            repopath,
+            srcpath
+        )?;
+        std::fs::remove_file(srcpath)?;
+        Ok(())
+    }
+}
+
+#[context("Generating test repo")]
+pub(crate) fn generate_test_repo(dir: &Utf8Path, testref: &str) -> Result<Utf8PathBuf> {
+    let src_tarpath = &dir.join("exampleos.tar.zst");
+    std::fs::write(src_tarpath, EXAMPLEOS_V0)?;
+
+    let gpghome = dir.join("gpghome");
+    {
+        let dec = flate2::read::GzDecoder::new(OSTREE_GPG_HOME);
+        let mut a = tar::Archive::new(dec);
+        a.unpack(&gpghome)?;
+    };
+
+    bash!(
+        indoc! {"
+        cd {dir}
+        ostree --repo=repo init --mode=archive
+        ostree --repo=repo commit -b {testref} --bootable --no-bindings --add-metadata=ostree.container-cmd='[\"/usr/bin/bash\"]' --add-metadata-string=version=42.0 --add-metadata-string=buildsys.checksum=41af286dc0b172ed2f1ca934fd2278de4a1192302ffa07087cea2682e7d372e3 --gpg-homedir={gpghome} --gpg-sign={keyid} \
+          --add-detached-metadata-string=my-detached-key=my-detached-value --tree=tar=exampleos.tar.zst >/dev/null
+        ostree --repo=repo show {testref} >/dev/null
+    "},
+        testref = testref,
+        gpghome = gpghome.as_str(),
+        keyid = TEST_GPG_KEYID_1,
+        dir = dir.as_str()
+    )?;
+    std::fs::remove_file(src_tarpath)?;
+    Ok(dir.join("repo"))
+}


### PR DESCRIPTION
OK so...buckle up.  I've been working on this ostree stuff for
like 10 years now it turns out that I still stuck at writing
the test suites.

When I generated the hardcoded `exampleos-v0.tar.zstd`, I apparently
included SELinux labels (I don't think intentionally).
But I didn't when generating `exampleos-v1.tar`!

I was trying to test an upgrade path around xattrs and hit a bug there
code, and it took me a while to understand it was because the second
update didn't have them!

The time it took to debug this was greatly extended by me reading
`man tar`, and thinking that `tar -tf -v --xattrs` would print any SELinux
label.  But no - SELinux is *special cased* in tar - even though
it's an extended attribute, in order to see any embedded labels
in the tarball one needs to use `tar -tf -v --selinux`!
Somehow I had apparently avoided learning this until now.  (ostree's
model I think is better than tar's, but here we're intersecting them)

Anyways.  None of this is fixed right now.  Yes, I can see the
disappointment.

But - in preparation for making the test suite more robust and
fixing things up, factor out the fixture as a separate module.
Make things like the testref a method instead of using a constant.

Port the diff test to use this too.