### PR TITLE
A few more test suite patches

### DIFF
--- a/lib/tests/it/fixture.rs
+++ b/lib/tests/it/fixture.rs
@@ -5,7 +5,6 @@ use cap_std_ext::prelude::CapStdExtCommandExt;
 use fn_error_context::context;
 use indoc::indoc;
 use ostree::cap_std;
-use ostree_ext::gio;
 use sh_inline::bash_in;
 use std::convert::TryInto;
 use std::process::Stdio;
@@ -27,7 +26,6 @@ pub(crate) struct Fixture {
     pub(crate) srcdir: Utf8PathBuf,
     pub(crate) srcrepo: ostree::Repo,
     pub(crate) destrepo: ostree::Repo,
-    pub(crate) destrepo_path: Utf8PathBuf,
 
     pub(crate) format_version: u32,
 }
@@ -67,11 +65,9 @@ impl Fixture {
             ostree::Repo::create_at_dir(srcdir_dfd, "repo", ostree::RepoMode::Archive, None)
                 .context("Creating src/ repo")?;
 
-        let destdir = &path.join("dest");
-        std::fs::create_dir(destdir)?;
-        let destrepo_path = destdir.join("repo");
-        let destrepo = ostree::Repo::new_for_path(&destrepo_path);
-        destrepo.create(ostree::RepoMode::BareUser, gio::NONE_CANCELLABLE)?;
+        dir.create_dir("dest")?;
+        let destrepo =
+            ostree::Repo::create_at_dir(&dir, "dest/repo", ostree::RepoMode::BareUser, None)?;
         Ok(Self {
             _tempdir: tempdir,
             dir,
@@ -79,7 +75,6 @@ impl Fixture {
             srcdir,
             srcrepo,
             destrepo,
-            destrepo_path,
             format_version: 0,
         })
     }

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -124,8 +124,7 @@ async fn test_tar_import_signed() -> Result<()> {
 
     // And signed correctly
     bash_in!(&fixture.dir,
-        "ostree --repo=dest/repo remote gpg-import --stdin myremote < ${p}/gpghome/key1.asc >/dev/null",
-        p = fixture.srcdir.as_str()
+        "ostree --repo=dest/repo remote gpg-import --stdin myremote < src/gpghome/key1.asc >/dev/null",
     )?;
     let src_tar = tokio::fs::File::open(test_tar).await?;
     let imported = ostree_ext::tar::import_tar(
@@ -446,8 +445,7 @@ async fn test_container_import_export() -> Result<()> {
         .remote_add("myremote", None, Some(&opts.end()), gio::NONE_CANCELLABLE)?;
     bash_in!(
         &fixture.dir,
-        "ostree --repo=dest/repo remote gpg-import --stdin myremote < ${p}/gpghome/key1.asc",
-        p = fixture.srcdir.as_str()
+        "ostree --repo=dest/repo remote gpg-import --stdin myremote < src/gpghome/key1.asc",
     )?;
 
     // No remote matching

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -1,7 +1,7 @@
 mod fixture;
 
 use anyhow::{Context, Result};
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8Path;
 use fn_error_context::context;
 use once_cell::sync::Lazy;
 use ostree_ext::container::store::PrepareResult;
@@ -10,7 +10,7 @@ use ostree_ext::container::{
 };
 use ostree_ext::tar::TarImportOptions;
 use ostree_ext::{gio, glib};
-use sh_inline::{bash, bash_in};
+use sh_inline::bash_in;
 use std::collections::HashMap;
 use std::{io::Write, process::Command};
 
@@ -34,7 +34,7 @@ static TEST_REGISTRY: Lazy<String> = Lazy::new(|| match std::env::var_os("TEST_R
 });
 
 #[context("Generating test tarball")]
-fn initial_export(fixture: &Fixture) -> Result<Utf8PathBuf> {
+fn initial_export(fixture: &Fixture) -> Result<&'static Utf8Path> {
     let cancellable = gio::NONE_CANCELLABLE;
     let (_, rev) = fixture
         .srcrepo
@@ -46,15 +46,15 @@ fn initial_export(fixture: &Fixture) -> Result<Utf8PathBuf> {
             .as_str(),
         EXAMPLEOS_CONTENT_CHECKSUM
     );
-    let destpath = fixture.path.join("exampleos-export.tar");
-    let mut outf = std::io::BufWriter::new(std::fs::File::create(&destpath)?);
+    let path = "exampleos-export.tar";
+    let mut outf = std::io::BufWriter::new(fixture.dir.create(path)?);
     let options = ostree_ext::tar::ExportOptions {
         format_version: fixture.format_version,
         ..Default::default()
     };
     ostree_ext::tar::export_commit(&fixture.srcrepo, rev.as_str(), &mut outf, Some(options))?;
     outf.flush()?;
-    Ok(destpath)
+    Ok(path.into())
 }
 
 #[tokio::test]
@@ -90,10 +90,10 @@ async fn test_tar_export_reproducible() -> Result<()> {
 #[tokio::test]
 async fn test_tar_import_signed() -> Result<()> {
     let fixture = Fixture::new()?;
-    let test_tar = &initial_export(&fixture)?;
+    let test_tar = initial_export(&fixture)?;
 
     // Verify we fail with an unknown remote.
-    let src_tar = tokio::fs::File::open(test_tar).await?;
+    let src_tar = tokio::fs::File::from_std(fixture.dir.open(test_tar)?.into_std());
     let r = ostree_ext::tar::import_tar(
         &fixture.destrepo,
         src_tar,
@@ -111,7 +111,7 @@ async fn test_tar_import_signed() -> Result<()> {
     fixture
         .destrepo
         .remote_add("myremote", None, Some(&opts.end()), gio::NONE_CANCELLABLE)?;
-    let src_tar = tokio::fs::File::open(test_tar).await?;
+    let src_tar = tokio::fs::File::from_std(fixture.dir.open(test_tar)?.into_std());
     let r = ostree_ext::tar::import_tar(
         &fixture.destrepo,
         src_tar,
@@ -126,7 +126,7 @@ async fn test_tar_import_signed() -> Result<()> {
     bash_in!(&fixture.dir,
         "ostree --repo=dest/repo remote gpg-import --stdin myremote < src/gpghome/key1.asc >/dev/null",
     )?;
-    let src_tar = tokio::fs::File::open(test_tar).await?;
+    let src_tar = tokio::fs::File::from_std(fixture.dir.open(test_tar)?.into_std());
     let imported = ostree_ext::tar::import_tar(
         &fixture.destrepo,
         src_tar,
@@ -215,7 +215,7 @@ fn test_tar_export_structure() -> Result<()> {
 
     let mut fixture = Fixture::new()?;
     let src_tar = initial_export(&fixture)?;
-    let src_tar = std::io::BufReader::new(std::fs::File::open(&src_tar)?);
+    let src_tar = std::io::BufReader::new(fixture.dir.open(src_tar)?);
     let mut src_tar = tar::Archive::new(src_tar);
     let mut entries = src_tar.entries()?;
     // The first entry should be the root directory.
@@ -254,7 +254,7 @@ fn test_tar_export_structure() -> Result<()> {
     // Validate format version 1
     fixture.format_version = 1;
     let src_tar = initial_export(&fixture)?;
-    let src_tar = std::io::BufReader::new(std::fs::File::open(&src_tar)?);
+    let src_tar = std::io::BufReader::new(fixture.dir.open(src_tar)?);
     let mut src_tar = tar::Archive::new(src_tar);
     let expected = [
         ("sysroot/ostree/repo", Directory, 0o755),
@@ -285,8 +285,8 @@ fn test_tar_export_structure() -> Result<()> {
 #[tokio::test]
 async fn test_tar_import_export() -> Result<()> {
     let fixture = Fixture::new()?;
-    let p = &initial_export(&fixture)?;
-    let src_tar = tokio::fs::File::open(p).await?;
+    let p = initial_export(&fixture)?;
+    let src_tar = tokio::fs::File::from_std(fixture.dir.open(p)?.into_std());
 
     let imported_commit: String =
         ostree_ext::tar::import_tar(&fixture.destrepo, src_tar, None).await?;
@@ -313,22 +313,20 @@ async fn test_tar_import_export() -> Result<()> {
 async fn test_tar_write() -> Result<()> {
     let fixture = Fixture::new()?;
     // Test translating /etc to /usr/etc
-    let tmpetc = fixture.path.join("tmproot/etc");
-    std::fs::create_dir_all(&tmpetc)?;
-    std::fs::write(tmpetc.join("someconfig.conf"), b"")?;
-    let tmproot = tmpetc.parent().unwrap();
-    let tmpvarlib = &tmproot.join("var/lib");
-    std::fs::create_dir_all(tmpvarlib)?;
-    std::fs::write(tmpvarlib.join("foo.log"), "foolog")?;
-    std::fs::write(tmpvarlib.join("bar.log"), "barlog")?;
-    std::fs::create_dir_all(tmproot.join("boot"))?;
-    let tmptar = fixture.path.join("testlayer.tar");
-    bash!(
-        "tar cf ${tmptar} -C ${tmproot} .",
-        tmptar = tmptar.as_str(),
-        tmproot = tmproot.as_str()
-    )?;
-    let src = tokio::fs::File::open(&tmptar).await?;
+    fixture.dir.create_dir_all("tmproot/etc")?;
+    let tmproot = &fixture.dir.open_dir("tmproot")?;
+    let tmpetc = tmproot.open_dir("etc")?;
+    tmpetc.write("someconfig.conf", b"some config")?;
+    tmproot.create_dir_all("var/log")?;
+    let tmpvarlog = tmproot.open_dir("var/log")?;
+    tmpvarlog.write("foo.log", "foolog")?;
+    tmpvarlog.write("bar.log", "barlog")?;
+    tmproot.create_dir("boot")?;
+    let tmptar = "testlayer.tar";
+    bash_in!(fixture.dir, "tar cf ${tmptar} -C tmproot .", tmptar)?;
+    let src = fixture.dir.open(tmptar)?;
+    fixture.dir.remove_file(tmptar)?;
+    let src = tokio::fs::File::from_std(src.into_std());
     let r = ostree_ext::tar::write_tar(&fixture.destrepo, src, "layer", None).await?;
     bash_in!(
         &fixture.dir,


### PR DESCRIPTION
tests: Split off fixture base prep from repo initialization

---

tests: Port to use more `bash_in!` and drop absolute paths

---

tests: Drop src absolute path

This patch series is staring to feel like spraying Windex on a dirty
window, and watching it get cleaner.

---

tests: Use cap-std in more places

---

tests: Move initial commit into fixture

---

