### PR TITLE
ostree-ext: release 0.6.4

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
-version = "0.6.3"
+version = "0.6.4"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Changes:
 * tar/export: add 'state' and 'extensions' repo subdirs
 * tests: Add much beefed up alternative path for test framework
 * lib/src/tar/write: make sure we add the links when filtering the tar
 * tests: two more small test suite patches
 * tar: Add a debug function to filter tar
 * cli: Use structopt's `TryFrom` support for parsing `ostree::Repo`
 * tests: A few more test suite patches
 * testsuite: Port to `sh-inline` 0.2
 * tar/import: Don't crash on extant object
 * tests: Factor out test fixture as a separate module
 * tar/export: use full path as link target
 * tar/export: export empty xattrs in v1 format
 * cli: Drop use of `select`
 * tar/v1: introduce object types for split xattrs
 * container: Hard depend on `skopeo copy --digestfile`
 * container/encapsulate: Support copying commit metadata keys
 * ocidir: More direct use of direct `_mut()` methods