### PR TITLE
tar/export: add 'state' and 'extensions' repo subdirs

### DIFF
--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -184,6 +184,12 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
             let path: Utf8PathBuf = format!("{}/{:02x}", objdir, d).into();
             self.append_default_dir(&path)?;
         }
+        // Extensions subdirectory
+        {
+            let path: Utf8PathBuf = format!("{}/repo/extensions", OSTREEDIR).into();
+            self.append_default_dir(&path)?;
+        }
+
         // Tmp subdirectories
         for d in ["tmp", "tmp/cache"] {
             let path: Utf8PathBuf = format!("{}/repo/{}", OSTREEDIR, d).into();
@@ -192,6 +198,11 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
         // Refs subdirectories
         for d in ["refs", "refs/heads", "refs/mirrors", "refs/remotes"] {
             let path: Utf8PathBuf = format!("{}/repo/{}", OSTREEDIR, d).into();
+            self.append_default_dir(&path)?;
+        }
+        // State subdirectory
+        {
+            let path: Utf8PathBuf = format!("{}/repo/state", OSTREEDIR).into();
             self.append_default_dir(&path)?;
         }
 

--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -184,25 +184,19 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
             let path: Utf8PathBuf = format!("{}/{:02x}", objdir, d).into();
             self.append_default_dir(&path)?;
         }
-        // Extensions subdirectory
-        {
-            let path: Utf8PathBuf = format!("{}/repo/extensions", OSTREEDIR).into();
-            self.append_default_dir(&path)?;
-        }
-
-        // Tmp subdirectories
-        for d in ["tmp", "tmp/cache"] {
+        // Standard repo subdirectories.
+        let subdirs = [
+            "extensions",
+            "refs",
+            "refs/heads",
+            "refs/mirrors",
+            "refs/remotes",
+            "state",
+            "tmp",
+            "tmp/cache",
+        ];
+        for d in subdirs {
             let path: Utf8PathBuf = format!("{}/repo/{}", OSTREEDIR, d).into();
-            self.append_default_dir(&path)?;
-        }
-        // Refs subdirectories
-        for d in ["refs", "refs/heads", "refs/mirrors", "refs/remotes"] {
-            let path: Utf8PathBuf = format!("{}/repo/{}", OSTREEDIR, d).into();
-            self.append_default_dir(&path)?;
-        }
-        // State subdirectory
-        {
-            let path: Utf8PathBuf = format!("{}/repo/state", OSTREEDIR).into();
             self.append_default_dir(&path)?;
         }
 

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -215,6 +215,7 @@ fn test_tar_export_structure() -> Result<()> {
     let expected = [
         ("sysroot/config", Regular, 0o644),
         ("sysroot/ostree/repo", Directory, 0o755),
+        ("sysroot/ostree/repo/extensions", Directory, 0o755),
         ("sysroot/ostree/repo/objects/00", Directory, 0o755),
         ("sysroot/ostree/repo/objects/23", Directory, 0o755),
         ("sysroot/ostree/repo/objects/77", Directory, 0o755),
@@ -225,6 +226,7 @@ fn test_tar_export_structure() -> Result<()> {
         ("sysroot/ostree/repo/refs/heads", Directory, 0o755),
         ("sysroot/ostree/repo/refs/mirrors", Directory, 0o755),
         ("sysroot/ostree/repo/refs/remotes", Directory, 0o755),
+        ("sysroot/ostree/repo/state", Directory, 0o755),
         ("sysroot/ostree/repo/tmp", Directory, 0o755),
         ("sysroot/ostree/repo/tmp/cache", Directory, 0o755),
         ("sysroot/ostree/repo/xattrs", Directory, 0o755),
@@ -244,6 +246,7 @@ fn test_tar_export_structure() -> Result<()> {
     let expected = [
         ("sysroot/ostree/repo", Directory, 0o755),
         ("sysroot/ostree/repo/config", Regular, 0o644),
+        ("sysroot/ostree/repo/extensions", Directory, 0o755),
         ("sysroot/ostree/repo/objects/00", Directory, 0o755),
         ("sysroot/ostree/repo/objects/23", Directory, 0o755),
         ("sysroot/ostree/repo/objects/77", Directory, 0o755),
@@ -254,6 +257,7 @@ fn test_tar_export_structure() -> Result<()> {
         ("sysroot/ostree/repo/refs/heads", Directory, 0o755),
         ("sysroot/ostree/repo/refs/mirrors", Directory, 0o755),
         ("sysroot/ostree/repo/refs/remotes", Directory, 0o755),
+        ("sysroot/ostree/repo/state", Directory, 0o755),
         ("sysroot/ostree/repo/tmp", Directory, 0o755),
         ("sysroot/ostree/repo/tmp/cache", Directory, 0o755),
         ("usr", Directory, 0o755),

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -331,7 +331,7 @@ async fn test_tar_write_tar_layer() -> Result<()> {
     let uncompressed_tar = tokio::io::BufReader::new(
         async_compression::tokio::bufread::GzipDecoder::new(EXAMPLE_TAR_LAYER),
     );
-    ostree_ext::tar::write_tar(&fixture.destrepo, uncompressed_tar, "test", None).await?;
+    ostree_ext::tar::write_tar(&fixture.destrepo(), uncompressed_tar, "test", None).await?;
     Ok(())
 }
 


### PR DESCRIPTION
This adds two missing standard repo subdirectories, `state` and `extensions`. The former is required for proper `fsck` usage.

It also fixes an unrelated test which is currently not building, due to a merge overlap.