### PR TITLE
tar/export: Fix duplicate xattrs in tar stream

### DIFF
--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -301,15 +301,15 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
 
         let xattrs_checksum = {
             let digest = openssl::hash::hash(openssl::hash::MessageDigest::sha256(), xattrs_data)?;
-            &hex::encode(digest)
+            hex::encode(digest)
         };
 
         if self.options.format_version == 0 {
-            let path = v0_xattrs_path(xattrs_checksum);
+            let path = v0_xattrs_path(&xattrs_checksum);
 
             // Write xattrs content into a separate directory.
-            if !self.wrote_xattrs.contains(xattrs_checksum) {
-                let inserted = self.wrote_xattrs.insert(checksum.to_string());
+            if !self.wrote_xattrs.contains(&xattrs_checksum) {
+                let inserted = self.wrote_xattrs.insert(xattrs_checksum);
                 debug_assert!(inserted);
                 self.append_default_data(&path, xattrs_data)?;
             }
@@ -319,11 +319,11 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
                 self.append_default_hardlink(&objpath, &path)?;
             }
         } else if self.options.format_version == 1 {
-            let path = v1_xattrs_object_path(xattrs_checksum);
+            let path = v1_xattrs_object_path(&xattrs_checksum);
 
             // Write xattrs content into a separate `.file-xattrs` object.
-            if !self.wrote_xattrs.contains(xattrs_checksum) {
-                let inserted = self.wrote_xattrs.insert(checksum.to_string());
+            if !self.wrote_xattrs.contains(&xattrs_checksum) {
+                let inserted = self.wrote_xattrs.insert(xattrs_checksum);
                 debug_assert!(inserted);
                 self.append_default_data(&path, xattrs_data)?;
             }


### PR DESCRIPTION
The containers/storage stack fails if it sees duplicate files.

Fix the bug introduced in the format version rework that passed
the object checksum instead of the xattrs checksum into the "seen"
map.

While we have the patient open, I noticed that we can optimize
things a bit and pass ownership of the checksum into the map.