### PR TITLE
Fix a few clippy lints from new Rust 1.59 version

### DIFF
--- a/lib/src/container/encapsulate.rs
+++ b/lib/src/container/encapsulate.rs
@@ -118,7 +118,7 @@ fn build_oci(
 
     labels.insert(OSTREE_COMMIT_LABEL.into(), commit.into());
 
-    for (k, v) in config.labels.iter().map(|k| k.iter()).flatten() {
+    for (k, v) in config.labels.iter().flat_map(|k| k.iter()) {
         labels.insert(k.into(), v.into());
     }
     // Lookup the cmd embedded in commit metadata

--- a/lib/src/refescape.rs
+++ b/lib/src/refescape.rs
@@ -129,8 +129,7 @@ fn unescape_for_ref(s: &str) -> Result<String> {
 pub fn unprefix_unescape_ref(prefix: &str, ostree_ref: &str) -> Result<String> {
     let rest = ostree_ref
         .strip_prefix(prefix)
-        .map(|s| s.strip_prefix('/'))
-        .flatten()
+        .and_then(|s| s.strip_prefix('/'))
         .ok_or_else(|| {
             anyhow::anyhow!(
                 "ref does not match expected prefix {}/: {}",


### PR DESCRIPTION
Fix a few clippy lints from new Rust 1.59 version

---

