### PR TITLE
bootabletree: New module with helpers for bootable ostree commits

### DIFF
--- a/lib/src/bootabletree.rs
+++ b/lib/src/bootabletree.rs
@@ -1,0 +1,29 @@
+//! Helper functions for bootable OSTrees.
+
+use anyhow::Result;
+use ostree::gio;
+use ostree::prelude::*;
+
+const MODULES: &str = "/usr/lib/modules";
+
+/// Find the kernel modules directory in a bootable OSTree commit.
+pub fn find_kernel_dir(
+    root: &gio::File,
+    cancellable: Option<&gio::Cancellable>,
+) -> Result<Option<gio::File>> {
+    let moddir = root.resolve_relative_path(MODULES);
+    let e = moddir.enumerate_children(
+        "standard::name",
+        gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS,
+        cancellable,
+    )?;
+    let mut r = None;
+    for child in e.clone() {
+        let child = &child?;
+        let childpath = e.child(child);
+        if child.file_type() == gio::FileType::Directory && r.replace(childpath).is_some() {
+            anyhow::bail!("Found multiple subdirectories in {}", MODULES);
+        }
+    }
+    Ok(r)
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -26,6 +26,7 @@ type Result<T> = anyhow::Result<T>;
 // Import global functions.
 mod globals;
 
+pub mod bootabletree;
 pub mod cli;
 pub mod container;
 pub mod container_utils;

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -5,6 +5,7 @@ use ostree_ext::container::store::PrepareResult;
 use ostree_ext::container::{
     Config, ImageReference, OstreeImageReference, SignatureSource, Transport,
 };
+use ostree_ext::prelude::FileExt;
 use ostree_ext::tar::TarImportOptions;
 use ostree_ext::{gio, glib};
 use sh_inline::bash_in;
@@ -300,6 +301,17 @@ async fn test_tar_import_export() -> Result<()> {
         "#,
         imported_commit = imported_commit.as_str()
     )?;
+
+    let (root, _) = fixture
+        .destrepo()
+        .read_commit(&imported_commit, gio::NONE_CANCELLABLE)?;
+    let kdir = ostree_ext::bootabletree::find_kernel_dir(&root, gio::NONE_CANCELLABLE)?;
+    let kdir = kdir.unwrap();
+    assert_eq!(
+        kdir.basename().unwrap().to_str().unwrap(),
+        "5.10.18-200.x86_64"
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
Right now this only offers an API to find the kernel directory,
but I could imagine we do more stuff here in the future.

I think this will be generally useful (e.g. ostree and rpm-ostree have
duplicate code for this) as is, but it's specifically prep for using
this in container layer splitting.