### PR TITLE
Fix clippy lints with `cargo 1.60.0-beta.1 (ea2a21c 2022-02-15)`

### DIFF
--- a/lib/src/container/encapsulate.rs
+++ b/lib/src/container/encapsulate.rs
@@ -124,6 +124,9 @@ fn build_oci(
     // Lookup the cmd embedded in commit metadata
     let cmd = commit_meta.lookup::<Vec<String>>(ostree::COMMIT_META_CONTAINER_CMD)?;
     // But support it being overridden by CLI options
+
+    // https://github.com/rust-lang/rust-clippy/pull/7639#issuecomment-1050340564
+    #[allow(clippy::unnecessary_lazy_evaluations)]
     let cmd = config.cmd.as_ref().or_else(|| cmd.as_ref());
     if let Some(cmd) = cmd {
         ctrcfg.set_cmd(Some(cmd.clone()));

--- a/lib/src/tar/write.rs
+++ b/lib/src/tar/write.rs
@@ -193,7 +193,7 @@ async fn filter_tar_async(
     let copier = tokio::io::copy(&mut rx_buf, &mut dest);
     let (r, v) = tokio::join!(tar_transformer, copier);
     let _v: u64 = v?;
-    Ok(r??)
+    r?
 }
 
 /// Write the contents of a tarball as an ostree commit.


### PR DESCRIPTION
I decided to suppress the ref-vs-not ref one for now, hopefully
clippy gets fixed.