### PR TITLE
tests: Port two tests to v1 fixture

### DIFF
--- a/lib/src/fixture.rs
+++ b/lib/src/fixture.rs
@@ -138,6 +138,8 @@ d run
 m 0 0 1755
 d tmp
 "## };
+pub const CONTENTS_CHECKSUM_V0: &str =
+    "76f0d5ec8814bc2a1d7868dbe8d3783535dc0cc9c7dcfdf37fa3512f8e276f6c";
 
 #[derive(Debug, PartialEq, Eq)]
 enum SeLabel {
@@ -393,6 +395,14 @@ impl Fixture {
         self.srcrepo
             .transaction_set_ref(None, self.testref(), Some(commit.as_str()));
         tx.commit(cancellable)?;
+
+        let gpghome = self.path.join("src/gpghome");
+        self.srcrepo.sign_commit(
+            &commit,
+            TEST_GPG_KEYID_1,
+            Some(gpghome.as_str()),
+            gio::NONE_CANCELLABLE,
+        )?;
 
         Ok(())
     }

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -13,7 +13,7 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::process::Command;
 
-use ostree_ext::fixture::{FileDef, Fixture};
+use ostree_ext::fixture::{FileDef, Fixture, CONTENTS_CHECKSUM_V0};
 
 const EXAMPLE_TAR_LAYER: &[u8] = include_bytes!("fixtures/hlinks.tar.gz");
 const EXAMPLEOS_CONTENT_CHECKSUM: &str =
@@ -35,7 +35,7 @@ static TEST_REGISTRY: Lazy<String> = Lazy::new(|| match std::env::var_os("TEST_R
 
 #[tokio::test]
 async fn test_tar_import_empty() -> Result<()> {
-    let fixture = Fixture::new()?;
+    let fixture = Fixture::new_v1()?;
     let r = ostree_ext::tar::import_tar(fixture.destrepo(), tokio::io::empty(), None).await;
     assert_err_contains(r, "Commit object not found");
     Ok(())
@@ -65,7 +65,7 @@ async fn test_tar_export_reproducible() -> Result<()> {
 
 #[tokio::test]
 async fn test_tar_import_signed() -> Result<()> {
-    let fixture = Fixture::new()?;
+    let fixture = Fixture::new_v1()?;
     let test_tar = fixture.export_tar()?;
 
     let rev = fixture.srcrepo().require_rev(fixture.testref())?;
@@ -74,7 +74,7 @@ async fn test_tar_import_signed() -> Result<()> {
         ostree::commit_get_content_checksum(&commitv)
             .unwrap()
             .as_str(),
-        EXAMPLEOS_CONTENT_CHECKSUM
+        CONTENTS_CHECKSUM_V0
     );
 
     // Verify we fail with an unknown remote.
@@ -122,7 +122,7 @@ async fn test_tar_import_signed() -> Result<()> {
     .await?;
     let (commitdata, state) = fixture.destrepo().load_commit(&imported)?;
     assert_eq!(
-        EXAMPLEOS_CONTENT_CHECKSUM,
+        CONTENTS_CHECKSUM_V0,
         ostree::commit_get_content_checksum(&commitdata)
             .unwrap()
             .as_str()


### PR DESCRIPTION
Add GPG signature on the commit object to match the current bits.