### PR TITLE
tests: Two more fixture porting patches

### DIFF
--- a/lib/src/fixture.rs
+++ b/lib/src/fixture.rs
@@ -396,6 +396,15 @@ impl Fixture {
             .transaction_set_ref(None, self.testref(), Some(commit.as_str()));
         tx.commit(cancellable)?;
 
+        let detached = glib::VariantDict::new(None);
+        detached.insert("my-detached-key", &"my-detached-value");
+        let detached = detached.to_variant();
+        self.srcrepo.write_commit_detached_metadata(
+            commit.as_str(),
+            Some(&detached),
+            gio::NONE_CANCELLABLE,
+        )?;
+
         let gpghome = self.path.join("src/gpghome");
         self.srcrepo.sign_commit(
             &commit,

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -315,7 +315,7 @@ async fn test_tar_import_export() -> Result<()> {
 
 #[tokio::test]
 async fn test_tar_write() -> Result<()> {
-    let fixture = Fixture::new()?;
+    let fixture = Fixture::new_v1()?;
     // Test translating /etc to /usr/etc
     fixture.dir.create_dir_all("tmproot/etc")?;
     let tmproot = &fixture.dir.open_dir("tmproot")?;
@@ -346,7 +346,7 @@ async fn test_tar_write() -> Result<()> {
 
 #[tokio::test]
 async fn test_tar_write_tar_layer() -> Result<()> {
-    let fixture = Fixture::new()?;
+    let fixture = Fixture::new_v1()?;
     let uncompressed_tar = tokio::io::BufReader::new(
         async_compression::tokio::bufread::GzipDecoder::new(EXAMPLE_TAR_LAYER),
     );


### PR DESCRIPTION
tests: Port two more tests to v1 fixture

Ongoing work to use the updated fixture.

---

tests: Port another two tests to v1 fixture

Ongoing work to use the updated fixture.

---

