### PR TITLE
tests: Port all remaining tests to v1 fixture

### DIFF
--- a/lib/src/fixture.rs
+++ b/lib/src/fixture.rs
@@ -382,12 +382,22 @@ impl Fixture {
         }
         let root = self.srcrepo.write_mtree(&root, cancellable)?;
         let root = root.downcast_ref::<ostree::RepoFile>().unwrap();
+        // You win internet points if you understand this date reference
         let ts = chrono::DateTime::parse_from_rfc2822("Fri, 29 Aug 1997 10:30:42 PST")?.timestamp();
+        // Some default metadata fixtures
+        let metadata = glib::VariantDict::new(None);
+        metadata.insert(
+            "buildsys.checksum",
+            &"41af286dc0b172ed2f1ca934fd2278de4a1192302ffa07087cea2682e7d372e3",
+        );
+        metadata.insert("ostree.container-cmd", &vec!["/usr/bin/bash"]);
+        metadata.insert("version", &"42.0");
+        let metadata = metadata.to_variant();
         let commit = self.srcrepo.write_commit_with_time(
             None,
             None,
             None,
-            None,
+            Some(&metadata),
             root,
             ts as u64,
             cancellable,
@@ -396,6 +406,7 @@ impl Fixture {
             .transaction_set_ref(None, self.testref(), Some(commit.as_str()));
         tx.commit(cancellable)?;
 
+        // Add detached metadata so we can verify it makes it through
         let detached = glib::VariantDict::new(None);
         detached.insert("my-detached-key", &"my-detached-value");
         let detached = detached.to_variant();

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -372,7 +372,7 @@ fn skopeo_inspect_config(imgref: &str) -> Result<oci_spec::image::ImageConfigura
 
 #[tokio::test]
 async fn test_container_import_export() -> Result<()> {
-    let fixture = Fixture::new()?;
+    let fixture = Fixture::new_v1()?;
     let testrev = fixture
         .srcrepo()
         .require_rev(fixture.testref())
@@ -473,7 +473,7 @@ async fn test_container_import_export() -> Result<()> {
     // Test without signature verification
     // Create a new repo
     {
-        let fixture = Fixture::new()?;
+        let fixture = Fixture::new_v1()?;
         let import =
             ostree_ext::container::unencapsulate(fixture.destrepo(), &srcoci_unverified, None)
                 .await
@@ -504,7 +504,7 @@ async fn oci_clone(src: impl AsRef<Utf8Path>, dest: impl AsRef<Utf8Path>) -> Res
 /// But layers work via the container::write module.
 #[tokio::test]
 async fn test_container_write_derive() -> Result<()> {
-    let fixture = Fixture::new()?;
+    let fixture = Fixture::new_v1()?;
     let base_oci_path = &fixture.path.join("exampleos.oci");
     let _digest = ostree_ext::container::encapsulate(
         fixture.srcrepo(),
@@ -709,7 +709,7 @@ async fn test_container_write_derive() -> Result<()> {
 // Then you can run this test via `env TEST_REGISTRY=quay.io/$myuser cargo test -- --ignored`.
 async fn test_container_import_export_registry() -> Result<()> {
     let tr = &*TEST_REGISTRY;
-    let fixture = Fixture::new()?;
+    let fixture = Fixture::new_v1()?;
     let testref = fixture.testref();
     let testrev = fixture
         .srcrepo()


### PR DESCRIPTION
Will remove the old one in a followup.