### PR TITLE
cli: Make parse functions public

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -21,15 +21,18 @@ use crate::container::store::{LayeredImageImporter, PrepareResult};
 use crate::container::{self as ostree_container, UnencapsulationProgress};
 use crate::container::{Config, ImageReference, OstreeImageReference, UnencapsulateOptions};
 
-fn parse_imgref(s: &str) -> Result<OstreeImageReference> {
+/// Parse an [`OstreeImageReference`] from a CLI arguemnt.
+pub fn parse_imgref(s: &str) -> Result<OstreeImageReference> {
     OstreeImageReference::try_from(s)
 }
 
-fn parse_base_imgref(s: &str) -> Result<ImageReference> {
+/// Parse a base [`ImageReference`] from a CLI arguemnt.
+pub fn parse_base_imgref(s: &str) -> Result<ImageReference> {
     ImageReference::try_from(s)
 }
 
-fn parse_repo(s: &str) -> Result<ostree::Repo> {
+/// Parse an [`ostree::Repo`] from a CLI arguemnt.
+pub fn parse_repo(s: &str) -> Result<ostree::Repo> {
     let repofd = cap_std::fs::Dir::open_ambient_dir(s, cap_std::ambient_authority())?;
     Ok(ostree::Repo::open_at_dir(&repofd, ".")?)
 }

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -31,6 +31,24 @@ static TEST_REGISTRY: Lazy<String> = Lazy::new(|| match std::env::var_os("TEST_R
     None => TEST_REGISTRY_DEFAULT.to_string(),
 });
 
+// This is mostly just sanity checking these functions are publicly accessible
+#[test]
+fn test_cli_fns() -> Result<()> {
+    let fixture = Fixture::new_v1()?;
+    let srcpath = fixture.path.join("src/repo");
+    let srcrepo_parsed = ostree_ext::cli::parse_repo(srcpath.as_str()).unwrap();
+    assert_eq!(srcrepo_parsed.mode(), fixture.srcrepo().mode());
+
+    let ir =
+        ostree_ext::cli::parse_imgref("ostree-unverified-registry:quay.io/examplens/exampleos")
+            .unwrap();
+    assert_eq!(ir.imgref.transport, Transport::Registry);
+
+    let ir = ostree_ext::cli::parse_base_imgref("docker://quay.io/examplens/exampleos").unwrap();
+    assert_eq!(ir.transport, Transport::Registry);
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_tar_import_empty() -> Result<()> {
     let fixture = Fixture::new_v1()?;


### PR DESCRIPTION
I want to use them in rpm-ostree too.