### PR TITLE
container: Add `--write-commitid-to` for `image deploy`

### DIFF
--- a/lib/src/container/deploy.rs
+++ b/lib/src/container/deploy.rs
@@ -1,5 +1,6 @@
 //! Perform initial setup for a container image based system root
 
+use super::store::LayeredImageState;
 use super::OstreeImageReference;
 use crate::container::store::PrepareResult;
 use anyhow::Result;
@@ -37,7 +38,7 @@ pub async fn deploy(
     stateroot: &str,
     imgref: &OstreeImageReference,
     options: Option<DeployOpts<'_>>,
-) -> Result<()> {
+) -> Result<Box<LayeredImageState>> {
     let cancellable = ostree::gio::NONE_CANCELLABLE;
     let options = options.unwrap_or_default();
     let repo = &sysroot.repo().unwrap();
@@ -66,5 +67,6 @@ pub async fn deploy(
     let flags = ostree::SysrootSimpleWriteDeploymentFlags::NONE;
     sysroot.simple_write_deployment(Some(stateroot), deployment, None, flags, cancellable)?;
     sysroot.cleanup(cancellable)?;
-    Ok(())
+
+    Ok(state)
 }


### PR DESCRIPTION
Right now in coreos-assembler we have code that wants to know
the exact deploy root, and for that with layered images we need
the merge commit ID.

First, change the deploy API to return the image state.  There's
no reason to just throw it away.

Add an option to the CLI which writes the commitid to a file.