### PR TITLE
Bump to 0.7.0 (lots of semver-incompat API changes)

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
-version = "0.6.5"
+version = "0.7.0"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
The biggest thing here was the merge of "chunked ostree" support in
https://github.com/ostreedev/ostree-rs-ext/pull/123
cascading into various API changes.

But I think it's working, let's cut 0.7 so the next rpm-ostree can
roll in the support.