### PR TITLE
ci: Add a test flow that does privileged integration testing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,3 +96,21 @@ jobs:
         run: install ostree-ext-cli /usr/bin && rm -v ostree-ext-cli
       - name: Integration tests
         run: ./ci/integration.sh
+  privtest:
+    name: "Privileged testing"
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/coreos-assembler/fcos:testing-devel
+      options: "--privileged -v /:/run/host"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Download
+        uses: actions/download-artifact@v2
+        with:
+          name: ostree-ext-cli
+      - name: Install
+        run: install ostree-ext-cli /usr/bin && rm -v ostree-ext-cli
+      - name: Integration tests
+        run: ./ci/priv-integration.sh

--- a/ci/priv-integration.sh
+++ b/ci/priv-integration.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Assumes that the current environment is a privileged container
+# with the host mounted at /run/host.  We can basically write
+# whatever we want, however we can't actually *reboot* the host.
+set -euo pipefail
+
+sysroot=/run/host
+# Current stable image fixture
+image=quay.io/coreos-assembler/fcos:testing-devel
+# My hand-uploaded chunked images
+chunked_image=quay.io/cgwalters/fcos-chunked:latest
+imgref=ostree-unverified-registry:${image}
+stateroot=testos
+
+set -x
+
+if test '!' -e "${sysroot}/ostree"; then
+    ostree admin init-fs --modern "${sysroot}"
+    ostree config --repo $sysroot/ostree/repo set sysroot.bootloader none
+fi
+ostree admin os-init "${stateroot}" --sysroot "${sysroot}"
+ostree-ext-cli container image deploy --sysroot "${sysroot}" \
+    --stateroot "${stateroot}" --imgref "${imgref}"
+ostree admin --sysroot="${sysroot}" status
+ostree-ext-cli container image deploy --sysroot "${sysroot}" \
+    --stateroot "${stateroot}" --imgref ostree-unverified-registry:"${chunked_image}"
+ostree admin --sysroot="${sysroot}" status


### PR DESCRIPTION
Trying to close the gap we have on this repository around
integration testing.  I am hopeful that by merging at least
the ostree{,-rs,-ext} repositories together we will get this
naturally in the future.

This first test crucially also uses the *existing* images as
fixtures, so we'll test compatibility with current ones.

I do still plan to set up OCP Prow for this repo to have reliable
nested virt CI, but...I realized that a pattern that is pretty
useful is that we can run a privileged container that "owns" the
host and execute code there too.

This current CI test actually doesn't run code directly on the
host, it uses ostree's `--sysroot` bits to just write files.

There are interesting aspects to this; for example while Ubuntu doesn't
use SELinux enabled by default, it does
have the kernel code enabled and we can write the `security.selinux`
xattrs just fine from FCOS.