### PR TITLE
container: Precise byte-level progress reporting

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
-version = "0.7.3"
+version = "0.8.0"
 
 [dependencies]
 anyhow = "1.0"

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -16,7 +16,7 @@ use structopt::StructOpt;
 use tokio::sync::mpsc::Receiver;
 
 use crate::commit::container_commit;
-use crate::container::store::{ImportProgress, PreparedImport};
+use crate::container::store::{ImportProgress, LayerProgress, PreparedImport};
 use crate::container::{self as ostree_container};
 use crate::container::{Config, ImageReference, OstreeImageReference};
 use ostree_container::store::{ImageImporter, PrepareResult};
@@ -187,6 +187,10 @@ enum ContainerImageOpts {
 
         #[structopt(flatten)]
         proxyopts: ContainerProxyOpts,
+
+        /// Don't display progress
+        #[structopt(long)]
+        quiet: bool,
     },
 
     /// Output metadata about an already stored container image.
@@ -398,9 +402,43 @@ pub fn layer_progress_format(p: &ImportProgress) -> String {
     }
 }
 
-async fn handle_layer_progress_print(mut r: Receiver<ImportProgress>) {
-    while let Some(v) = r.recv().await {
-        println!("{}", layer_progress_format(&v));
+async fn handle_layer_progress_print(
+    mut layers: Receiver<ImportProgress>,
+    mut layer_bytes: tokio::sync::watch::Receiver<Option<LayerProgress>>,
+) {
+    let style = indicatif::ProgressStyle::default_bar();
+    let pb = indicatif::ProgressBar::new(100);
+    pb.set_style(style.template("{prefix} {bytes} [{bar:20}] ({eta}) {msg}"));
+    loop {
+        tokio::select! {
+            // Always handle layer changes first.
+            biased;
+            layer = layers.recv() => {
+                if let Some(l) = layer {
+                    if l.is_starting() {
+                        pb.set_position(0);
+                    } else {
+                        pb.finish();
+                    }
+                    pb.set_message(layer_progress_format(&l));
+                } else {
+                    // If the receiver is disconnected, then we're done
+                    break
+                };
+            },
+            r = layer_bytes.changed() => {
+                if r.is_err() {
+                    // If the receiver is disconnected, then we're done
+                    break
+                }
+                let bytes = layer_bytes.borrow();
+                if let Some(bytes) = &*bytes {
+                    pb.set_length(bytes.total);
+                    pb.set_position(bytes.fetched);
+                }
+            }
+
+        }
     }
 }
 
@@ -498,9 +536,9 @@ async fn container_store(
     repo: &ostree::Repo,
     imgref: &OstreeImageReference,
     proxyopts: ContainerProxyOpts,
+    quiet: bool,
 ) -> Result<()> {
     let mut imp = ImageImporter::new(repo, imgref, proxyopts.into()).await?;
-    let layer_progress = imp.request_progress();
     let prep = match imp.prepare().await? {
         PrepareResult::AlreadyPresent(c) => {
             println!("No changes in {} => {}", imgref, c.merge_commit);
@@ -509,10 +547,17 @@ async fn container_store(
         PrepareResult::Ready(r) => r,
     };
     print_layer_status(&prep);
-    let progress_printer =
-        tokio::task::spawn(async move { handle_layer_progress_print(layer_progress).await });
+    let printer = (!quiet).then(|| {
+        let layer_progress = imp.request_progress();
+        let layer_byte_progress = imp.request_layer_progress();
+        tokio::task::spawn(async move {
+            handle_layer_progress_print(layer_progress, layer_byte_progress).await
+        })
+    });
     let import = imp.import(prep).await;
-    let _ = progress_printer.await;
+    if let Some(printer) = printer {
+        let _ = printer.await;
+    }
     let import = import?;
     let commit = &repo.load_commit(&import.merge_commit)?.0;
     let commit_meta = &glib::VariantDict::new(Some(&commit.child_value(0)));
@@ -672,7 +717,8 @@ where
                     repo,
                     imgref,
                     proxyopts,
-                } => container_store(&repo, &imgref, proxyopts).await,
+                    quiet,
+                } => container_store(&repo, &imgref, proxyopts, quiet).await,
                 ContainerImageOpts::History { repo, imgref } => {
                     container_history(&repo, &imgref).await
                 }

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -555,7 +555,7 @@ async fn impl_test_container_import_export(chunked: bool) -> Result<()> {
         sigverify: SignatureSource::OstreeRemote("unknownremote".to_string()),
         imgref: srcoci_imgref.clone(),
     };
-    let r = ostree_ext::container::unencapsulate(fixture.destrepo(), &srcoci_unknownremote, None)
+    let r = ostree_ext::container::unencapsulate(fixture.destrepo(), &srcoci_unknownremote)
         .await
         .context("importing");
     assert_err_contains(r, r#"Remote "unknownremote" not found"#);
@@ -575,7 +575,7 @@ async fn impl_test_container_import_export(chunked: bool) -> Result<()> {
         sigverify: SignatureSource::OstreeRemote("myremote".to_string()),
         imgref: srcoci_imgref.clone(),
     };
-    let import = ostree_ext::container::unencapsulate(fixture.destrepo(), &srcoci_verified, None)
+    let import = ostree_ext::container::unencapsulate(fixture.destrepo(), &srcoci_verified)
         .await
         .context("importing")?;
     assert_eq!(import.ostree_commit, testrev.as_str());
@@ -593,17 +593,16 @@ async fn impl_test_container_import_export(chunked: bool) -> Result<()> {
         imgref: temp_unsigned,
     };
     fixture.clear_destrepo()?;
-    let r = ostree_ext::container::unencapsulate(fixture.destrepo(), &temp_unsigned, None).await;
+    let r = ostree_ext::container::unencapsulate(fixture.destrepo(), &temp_unsigned).await;
     assert_err_contains(r, "Expected commitmeta object");
 
     // Test without signature verification
     // Create a new repo
     {
         let fixture = Fixture::new_v1()?;
-        let import =
-            ostree_ext::container::unencapsulate(fixture.destrepo(), &srcoci_unverified, None)
-                .await
-                .context("importing")?;
+        let import = ostree_ext::container::unencapsulate(fixture.destrepo(), &srcoci_unverified)
+            .await
+            .context("importing")?;
         assert_eq!(import.ostree_commit, testrev.as_str());
     }
 
@@ -824,7 +823,7 @@ async fn test_container_write_derive() -> Result<()> {
     assert!(images.is_empty());
 
     // Verify importing a derived image fails
-    let r = ostree_ext::container::unencapsulate(fixture.destrepo(), &derived_ref, None).await;
+    let r = ostree_ext::container::unencapsulate(fixture.destrepo(), &derived_ref).await;
     assert_err_contains(r, "Image has 1 non-ostree layers");
 
     // Pull a derived image - two layers, new base plus one layer.
@@ -986,7 +985,7 @@ async fn test_container_import_export_registry() -> Result<()> {
         sigverify: SignatureSource::ContainerPolicyAllowInsecure,
         imgref: digested_imgref,
     };
-    let import = ostree_ext::container::unencapsulate(fixture.destrepo(), &import_ref, None)
+    let import = ostree_ext::container::unencapsulate(fixture.destrepo(), &import_ref)
         .await
         .context("importing")?;
     assert_eq!(import.ostree_commit, testrev.as_str());


### PR DESCRIPTION
container: Remove current byte-level progress option

We need to rework this to have useful per-layer information.

---

container: Add new byte-level progress

This new byte-level progress API allows clients to render
fine-grained download progress of individual layers.

Notably, it replaces the previous broken API which operated
on the *decompressed* stream - but we don't know the total
size of that.  This one operates on the compressed stream,
and we have the total in the manifest so we can render
an accurate progress bar.

---

cli: Use byte progress for containers

We can now show an accurate download progress.

---

Closes: https://github.com/ostreedev/ostree-rs-ext/issues/277
