### PR TITLE
ima: various fixes

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -271,6 +271,10 @@ struct ImaSignOpts {
     algorithm: String,
     /// Path to IMA key
     key: Utf8PathBuf,
+
+    #[structopt(long)]
+    /// Overwrite any existing signatures
+    overwrite: bool,
 }
 
 /// Options for internal testing
@@ -544,6 +548,7 @@ fn ima_sign(cmdopts: &ImaSignOpts) -> Result<()> {
     let signopts = crate::ima::ImaOpts {
         algorithm: cmdopts.algorithm.clone(),
         key: cmdopts.key.clone(),
+        overwrite: cmdopts.overwrite,
     };
     let signed_commit = crate::ima::ima_sign(&cmdopts.repo, cmdopts.src_rev.as_str(), &signopts)?;
     cmdopts.repo.set_ref_immediate(

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -270,7 +270,7 @@ struct ImaSignOpts {
     /// Digest algorithm
     algorithm: String,
     /// Path to IMA key
-    key: String,
+    key: Utf8PathBuf,
 }
 
 /// Options for internal testing

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -545,18 +545,20 @@ async fn container_history(repo: &ostree::Repo, imgref: &OstreeImageReference) -
 
 /// Add IMA signatures to an ostree commit, generating a new commit.
 fn ima_sign(cmdopts: &ImaSignOpts) -> Result<()> {
+    let cancellable = gio::NONE_CANCELLABLE;
     let signopts = crate::ima::ImaOpts {
         algorithm: cmdopts.algorithm.clone(),
         key: cmdopts.key.clone(),
         overwrite: cmdopts.overwrite,
     };
+    let tx = cmdopts.repo.auto_transaction(cancellable)?;
     let signed_commit = crate::ima::ima_sign(&cmdopts.repo, cmdopts.src_rev.as_str(), &signopts)?;
-    cmdopts.repo.set_ref_immediate(
+    cmdopts.repo.transaction_set_ref(
         None,
         cmdopts.target_ref.as_str(),
         Some(signed_commit.as_str()),
-        gio::NONE_CANCELLABLE,
-    )?;
+    );
+    let _stats = tx.commit(cancellable)?;
     println!("{} => {}", cmdopts.target_ref, signed_commit);
     Ok(())
 }

--- a/lib/src/ima.rs
+++ b/lib/src/ima.rs
@@ -4,6 +4,7 @@
 
 use crate::objgv::*;
 use anyhow::{Context, Result};
+use camino::Utf8PathBuf;
 use cap_std_ext::rustix::fd::BorrowedFd;
 use fn_error_context::context;
 use gio::glib;
@@ -34,7 +35,7 @@ pub struct ImaOpts {
     pub algorithm: String,
 
     /// Path to IMA key
-    pub key: String,
+    pub key: Utf8PathBuf,
 }
 
 /// Convert a GVariant of type `a(ayay)` to a mutable map

--- a/lib/src/ima.rs
+++ b/lib/src/ima.rs
@@ -294,6 +294,9 @@ impl<'a> CommitRewriter<'a> {
 ///
 /// The generated commit object will inherit all metadata from the existing commit object
 /// such as version, etc.
+///
+/// This function does not create an ostree transaction; it's recommended to use outside the call
+/// to this function.
 pub fn ima_sign(repo: &ostree::Repo, ostree_ref: &str, opts: &ImaOpts) -> Result<String> {
     let writer = &mut CommitRewriter::new(repo, opts)?;
     writer.map_commit(ostree_ref)


### PR DESCRIPTION
ima: Clarify that key is a path

No functional changes, it's just clearer.

---

ima: Only do IMA signatures, not EVM

Now, there is high alignment between ostree and EVM around ensuring
that the security xattrs are immutable/signed too; but
as I understand things, this attribute is really intended to be
machine-local.

---

ima: Don't overwrite existing signatures by default

A use case here is where rpm-ostree may propagate existing IMA
signatures from RPMs, but one wants to add signatures for other
files that aren't signed (for example, the RPM database and non-packaged
files).

---

ima: Use an ostree transaction

It's cleaner and more efficient.

---

