### PR TITLE
Fix `history` command and `query_image` to accept plain `ImageReference`

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -193,15 +193,15 @@ enum ContainerImageOpts {
         proxyopts: ContainerProxyOpts,
     },
 
-    /// Pull (or update) a container image.
+    /// Output metadata about an already stored container image.
     History {
         /// Path to the repository
         #[structopt(long, parse(try_from_str = parse_repo))]
         repo: ostree::Repo,
 
-        /// Image reference, e.g. ostree-remote-image:someremote:registry:quay.io/exampleos/exampleos:latest
-        #[structopt(parse(try_from_str = parse_imgref))]
-        imgref: OstreeImageReference,
+        /// Container image reference, e.g. registry:quay.io/exampleos/exampleos:latest
+        #[structopt(parse(try_from_str = parse_base_imgref))]
+        imgref: ImageReference,
     },
 
     /// Copy a pulled container image from one repo to another.
@@ -542,8 +542,8 @@ fn print_column(s: &str, clen: usize, remaining: &mut usize) {
 }
 
 /// Output the container image history
-async fn container_history(repo: &ostree::Repo, imgref: &OstreeImageReference) -> Result<()> {
-    let img = crate::container::store::query_image(repo, imgref)?
+async fn container_history(repo: &ostree::Repo, imgref: &ImageReference) -> Result<()> {
+    let img = crate::container::store::query_image_ref(repo, imgref)?
         .ok_or_else(|| anyhow::anyhow!("No such image: {}", imgref))?;
     let columns = [("ID", 20), ("SIZE", 10), ("CREATED BY", 0usize)];
     let width = term_size::dimensions().map(|x| x.0).unwrap_or(80);

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -659,11 +659,11 @@ pub fn list_images(repo: &ostree::Repo) -> Result<Vec<String>> {
 }
 
 /// Query metadata for a pulled image.
-pub fn query_image(
+pub fn query_image_ref(
     repo: &ostree::Repo,
-    imgref: &OstreeImageReference,
+    imgref: &ImageReference,
 ) -> Result<Option<Box<LayeredImageState>>> {
-    let ostree_ref = &ref_for_image(&imgref.imgref)?;
+    let ostree_ref = &ref_for_image(imgref)?;
     let merge_rev = repo.resolve_rev(ostree_ref, true)?;
     let (merge_commit, merge_commit_obj) = if let Some(r) = merge_rev {
         (r.to_string(), repo.load_commit(r.as_str())?.0)
@@ -693,6 +693,17 @@ pub fn query_image(
     });
     tracing::debug!(state = ?state);
     Ok(Some(state))
+}
+
+/// Query metadata for a pulled image.
+///
+/// This is a thin wrapper for [`query_image_ref`] and should
+/// be considered deprecated.
+pub fn query_image(
+    repo: &ostree::Repo,
+    imgref: &OstreeImageReference,
+) -> Result<Option<Box<LayeredImageState>>> {
+    query_image_ref(repo, &imgref.imgref)
 }
 
 /// Copy a downloaded image from one repository to another.


### PR DESCRIPTION
This is a big confusing topic, because ostree tries to impose
higher level signing semantics on top of container image references.

For images that are already stored, we don't actually today store
that signing state, though we probably should.

Anyways, change this CLI to accept plain image references, and also
add a new query API that takes that directly.

Prep for adding other CLI verbs which should do the same.