### PR TITLE
build: Be compatible with cap-std-ext 0.25

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,7 +17,7 @@ bitflags = "1"
 camino = "1.0.4"
 chrono = "0.4.19"
 cjson = "0.1.1"
-cap-std-ext = "0.24"
+cap-std-ext = ">= 0.24, <= 0.25"
 flate2 = { features = ["zlib"], default_features = false, version = "1.0.20" }
 fn-error-context = "0.2.0"
 futures-util = "0.3.13"
@@ -46,7 +46,7 @@ tokio-stream = { features = ["sync"], version = "0.1.8" }
 tracing = "0.1"
 
 indoc = { version = "1.0.3", optional = true }
-sh-inline = { version = "0.2", features = ["cap-std-ext"], optional = true }
+sh-inline = { version = "0.2.2", features = ["cap-std-ext"], optional = true }
 
 [dev-dependencies]
 quickcheck = "1"


### PR DESCRIPTION
We only use the `cmdext` bits right now, not the atomic writes.
Widen our compatibility matrix so we can be built with both.