### PR TITLE
ci: make use of `cargo-deny` for baseline license check and crate dups

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,6 +76,14 @@ jobs:
           key: "min"
       - name: cargo check
         run: cargo check
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        log-level: warn
+        command: check bans sources licenses
   linting:
     name: "Lints, pinned toolchain"
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,10 @@
+[licenses]
+unlicensed = "deny"
+allow = ["Apache-2.0", "Apache-2.0 WITH LLVM-exception", "MIT", "BSD-3-Clause", "BSD-2-Clause"]
+
+[bans]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-git = []


### PR DESCRIPTION
See https://crates.io/crates/cargo-deny
This looks like a really nice tool, let's use it to validate
license compatibility mainly.   But I also added `sources` and
`bans`.