### PR TITLE
Fix extra NUL char in IMA xattr, add tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -121,6 +121,22 @@ jobs:
         run: install ostree-ext-cli /usr/bin && rm -v ostree-ext-cli
       - name: Integration tests
         run: ./ci/integration.sh
+  ima:
+    name: "Integration (IMA)"
+    needs: build
+    runs-on: ubuntu-latest
+    container: quay.io/coreos-assembler/fcos:testing-devel
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Download ostree-ext-cli
+        uses: actions/download-artifact@v2
+        with:
+          name: ostree-ext-cli
+      - name: Install
+        run: install ostree-ext-cli /usr/bin && rm -v ostree-ext-cli
+      - name: Integration tests
+        run: ./ci/ima.sh
   privtest:
     name: "Privileged testing"
     needs: build

--- a/ci/ima.sh
+++ b/ci/ima.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Assumes that the current environment is a mutable ostree-container
+# with ostree-ext-cli installed in /usr/bin.  
+# Runs IMA tests.
+set -xeuo pipefail
+
+if test '!' -x /usr/bin/evmctl; then
+    rpm-ostree install ima-evm-utils
+fi
+
+ostree-ext-cli internal-only-for-testing run-ima
+echo ok "ima"

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -302,6 +302,8 @@ enum TestingOpts {
     DetectEnv,
     /// Execute integration tests, assuming mutable environment
     Run,
+    /// Execute IMA tests
+    RunIMA,
     FilterTar,
 }
 
@@ -628,6 +630,7 @@ fn testing(opts: &TestingOpts) -> Result<()> {
             Ok(())
         }
         TestingOpts::Run => crate::integrationtest::run_tests(),
+        TestingOpts::RunIMA => crate::integrationtest::test_ima(),
         TestingOpts::FilterTar => {
             crate::tar::filter_tar(std::io::stdin(), std::io::stdout()).map(|_| {})
         }


### PR DESCRIPTION
I went to add testing for our IMA bits and I tripped over a bug; we
are going out of our way to store a trailing `NUL` character in
the ostree xattrs for the key name.  We should not do this, because
it will break fsck.  What we end up passing to the kernel looks like
`security.ima\0\0`, and the kernel being C will happily take that
to mean `security.ima`.  But the checksum we computed originally is
using `security.ima\0`, not what we will read back from disk as
`security.ima`.