### PR TITLE
import: Fix error message for missing commit metadata

### DIFF
--- a/lib/src/tar/import.rs
+++ b/lib/src/tar/import.rs
@@ -654,7 +654,7 @@ impl Importer {
                 return Err(anyhow!(
                     "Using remote {} for verification; Expected commitmeta object, not {:?}",
                     remote,
-                    objtype
+                    next_objtype
                 ));
             }
             if next_checksum != checksum {


### PR DESCRIPTION
I'm writing some code around changing commit metadata, and
it took me an embarassingly long amount of time to figure out
that it wasn't my code that was broken - it was this error message.

In this case, output the actual next object type we found instead
of saying "commit" which we already did find.