### PR TITLE
lib: Bump to ostree-rs 0.14

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -31,7 +31,7 @@ oci-spec = "0.5.4"
 openat = "0.1.20"
 openat-ext = "0.2.0"
 openssl = "0.10.33"
-ostree = { features = ["v2021_5", "cap-std-apis"], version = "0.13.5" }
+ostree = { features = ["v2021_5", "cap-std-apis"], version = "0.14.0" }
 pin-project = "1.0"
 regex = "1.5.4"
 serde = { features = ["derive"], version = "1.0.125" }

--- a/lib/src/chunking.rs
+++ b/lib/src/chunking.rs
@@ -83,8 +83,7 @@ impl ObjectMetaSized {
         let mut sizes = HashMap::<&str, u64>::new();
         // Populate two mappings above, iterating over the object -> contentid mapping
         for (checksum, contentid) in map.iter() {
-            let (_, finfo, _) = repo.load_file(checksum, cancellable)?;
-            let finfo = finfo.unwrap();
+            let finfo = repo.query_file(checksum, cancellable)?.0;
             let sz = sizes.entry(contentid).or_default();
             *sz += finfo.size() as u64;
         }


### PR DESCRIPTION
This bumped ostree semver, and since we re-export it also bumps
ours, but we've already got that queued.

When doing this I went to see if there were any new APIs that
we should be using, and saw https://github.com/ostreedev/ostree-rs/pull/50
and was like "ah hah, I remember that now" and a quick grep found
the place I wanted to use it.