### PR TITLE
container/tar: Prep patches for export fixes

### DIFF
--- a/lib/src/chunking.rs
+++ b/lib/src/chunking.rs
@@ -107,8 +107,6 @@ impl ObjectMetaSized {
 #[derive(Debug, Default)]
 pub struct Chunking {
     pub(crate) metadata_size: u64,
-    #[allow(dead_code)]
-    pub(crate) commit: Box<str>,
     pub(crate) meta: Vec<Meta>,
     pub(crate) remainder: Chunk,
     pub(crate) chunks: Vec<Chunk>,
@@ -259,7 +257,6 @@ impl Chunking {
         generate_chunking_recurse(repo, &mut gen, &mut chunk, &contents_v)?;
 
         let chunking = Chunking {
-            commit: Box::from(rev.as_str()),
             metadata_size: gen.metadata_size,
             meta: gen.meta,
             remainder: chunk,

--- a/lib/src/chunking.rs
+++ b/lib/src/chunking.rs
@@ -107,6 +107,7 @@ impl ObjectMetaSized {
 #[derive(Debug, Default)]
 pub struct Chunking {
     pub(crate) metadata_size: u64,
+    #[allow(dead_code)]
     pub(crate) commit: Box<str>,
     pub(crate) meta: Vec<Meta>,
     pub(crate) remainder: Chunk,

--- a/lib/src/chunking.rs
+++ b/lib/src/chunking.rs
@@ -23,11 +23,12 @@ use serde::{Deserialize, Serialize};
 pub(crate) const MAX_CHUNKS: u32 = 64;
 
 type RcStr = Rc<str>;
+pub(crate) type ChunkMapping = BTreeMap<RcStr, (u64, Vec<Utf8PathBuf>)>;
 
 #[derive(Debug, Default)]
 pub(crate) struct Chunk {
     pub(crate) name: String,
-    pub(crate) content: BTreeMap<RcStr, (u64, Vec<Utf8PathBuf>)>,
+    pub(crate) content: ChunkMapping,
     pub(crate) size: u64,
 }
 

--- a/lib/src/container/encapsulate.rs
+++ b/lib/src/container/encapsulate.rs
@@ -92,7 +92,7 @@ fn export_chunked(
         .enumerate()
         .map(|(i, chunk)| -> Result<_> {
             let mut w = ociw.create_layer(compression)?;
-            ostree_tar::export_chunk(repo, commit, &chunk, &mut w)
+            ostree_tar::export_chunk(repo, commit, chunk.content, &mut w)
                 .with_context(|| format!("Exporting chunk {i}"))?;
             let w = w.into_inner()?;
             Ok((w.complete()?, chunk.name))
@@ -102,7 +102,7 @@ fn export_chunked(
         ociw.push_layer(manifest, imgcfg, layer, &name);
     }
     let mut w = ociw.create_layer(compression)?;
-    ostree_tar::export_final_chunk(repo, commit, &chunking, &mut w)?;
+    ostree_tar::export_final_chunk(repo, commit, chunking, &mut w)?;
     let w = w.into_inner()?;
     let final_layer = w.complete()?;
     labels.insert(

--- a/lib/src/container/encapsulate.rs
+++ b/lib/src/container/encapsulate.rs
@@ -77,6 +77,7 @@ fn commit_meta_to_labels<'a>(
 #[allow(clippy::too_many_arguments)]
 fn export_chunked(
     repo: &ostree::Repo,
+    commit: &str,
     ociw: &mut OciDir,
     manifest: &mut oci_image::ImageManifest,
     imgcfg: &mut oci_image::ImageConfiguration,
@@ -91,7 +92,7 @@ fn export_chunked(
         .enumerate()
         .map(|(i, chunk)| -> Result<_> {
             let mut w = ociw.create_layer(compression)?;
-            ostree_tar::export_chunk(repo, &chunk, &mut w)
+            ostree_tar::export_chunk(repo, commit, &chunk, &mut w)
                 .with_context(|| format!("Exporting chunk {i}"))?;
             let w = w.into_inner()?;
             Ok((w.complete()?, chunk.name))
@@ -101,7 +102,7 @@ fn export_chunked(
         ociw.push_layer(manifest, imgcfg, layer, &name);
     }
     let mut w = ociw.create_layer(compression)?;
-    ostree_tar::export_final_chunk(repo, &chunking, &mut w)?;
+    ostree_tar::export_final_chunk(repo, commit, &chunking, &mut w)?;
     let w = w.into_inner()?;
     let final_layer = w.complete()?;
     labels.insert(
@@ -182,6 +183,7 @@ fn build_oci(
     if let Some(chunking) = chunking {
         export_chunked(
             repo,
+            commit,
             &mut writer,
             &mut manifest,
             &mut imgcfg,

--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -139,8 +139,8 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
         commit_checksum: &'a str,
         out: &'a mut tar::Builder<W>,
         options: ExportOptions,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        let r = Self {
             repo,
             commit_checksum,
             out,
@@ -150,7 +150,8 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
             wrote_dirtree: HashSet::new(),
             wrote_content: HashSet::new(),
             wrote_xattrs: HashSet::new(),
-        }
+        };
+        Ok(r)
     }
 
     /// Convert the ostree mode to tar mode.
@@ -538,7 +539,7 @@ fn impl_export<W: std::io::Write>(
     out: &mut tar::Builder<W>,
     options: ExportOptions,
 ) -> Result<()> {
-    let writer = &mut OstreeTarWriter::new(repo, commit_checksum, out, options);
+    let writer = &mut OstreeTarWriter::new(repo, commit_checksum, out, options)?;
     writer.write_commit()?;
     Ok(())
 }
@@ -596,7 +597,7 @@ pub(crate) fn export_chunk<W: std::io::Write>(
     chunk: chunking::ChunkMapping,
     out: &mut tar::Builder<W>,
 ) -> Result<()> {
-    let writer = &mut OstreeTarWriter::new(repo, commit, out, ExportOptions::default());
+    let writer = &mut OstreeTarWriter::new(repo, commit, out, ExportOptions::default())?;
     writer.write_repo_structure()?;
     write_chunk(writer, chunk)
 }
@@ -616,7 +617,7 @@ pub(crate) fn export_final_chunk<W: std::io::Write>(
         format_version: 1,
         ..Default::default()
     };
-    let writer = &mut OstreeTarWriter::new(repo, commit_checksum, out, options);
+    let writer = &mut OstreeTarWriter::new(repo, commit_checksum, out, options)?;
     writer.write_repo_structure()?;
 
     let (commit_v, _) = repo.load_commit(&chunking.commit)?;

--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -1,7 +1,6 @@
 //! APIs for creating container images from OSTree commits
 
 use crate::chunking;
-use crate::chunking::Chunking;
 use crate::objgv::*;
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
@@ -612,7 +611,7 @@ pub(crate) fn export_chunk<W: std::io::Write>(
 pub(crate) fn export_final_chunk<W: std::io::Write>(
     repo: &ostree::Repo,
     commit_checksum: &str,
-    chunking: Chunking,
+    chunking: chunking::Chunking,
     out: &mut tar::Builder<W>,
 ) -> Result<()> {
     let cancellable = gio::NONE_CANCELLABLE;


### PR DESCRIPTION
container/tar: Thread commit checksum down into tar writer

Prep for future refactoring where we will want to cache things
related to it.  We don't have any design for emitting multiple
commits into a single tar stream, so drop that implicit ability.

---

container/tar: Pass ownership of chunks down into export

There's no reason to keep all the data alive until the export is
done, and it may allow us to optimize things in the future.

---

tar/export: Make constructor fallible

Prep for a future patch which will add actually fallible code there.

---

tar/export: Load and cache commit object

The writer can only write a single commit.  Having this data
already loaded will help with future patches for the chunked
export.

---

