### PR TITLE
Use single-threaded tokio by default

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,7 +13,7 @@ ostree-ext = { path = "../lib" }
 clap = "2.33.3"
 structopt = "0.3.21"
 libc = "0.2.92"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["io-std", "macros"] }
 log = "0.4.0"
 tracing = "0.1"
 tracing-subscriber = "0.2.17"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,7 +10,7 @@ async fn run() -> Result<()> {
     ostree_ext::cli::run_from_iter(std::env::args_os()).await
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     if let Err(e) = run().await {
         eprintln!("error: {:#}", e);

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.8.0"
 
 [dependencies]
 anyhow = "1.0"
-containers-image-proxy = "0.5.0"
+containers-image-proxy = "0.5.1"
 
 async-compression = { version = "0.3", features = ["gzip", "tokio"] }
 bitflags = "1"
@@ -39,7 +39,7 @@ structopt = "0.3.21"
 tar = "0.4.38"
 tempfile = "3.2.0"
 term_size = "0.3.2"
-tokio = { features = ["full"], version = ">= 1.13.0" }
+tokio = { features = ["time", "process", "rt", "net"], version = ">= 1.13.0" }
 tokio-util = { features = ["io-util"], version = "0.6.9" }
 tokio-stream = { features = ["sync"], version = "0.1.8" }
 tracing = "0.1"


### PR DESCRIPTION
I saw https://www.reddit.com/r/rust/comments/v8e9fa/local_async_executors_and_why_they_should_be_the/
go by and I think it's a good argument why one should use single-threaded
tokio by default.

There's more to do around potentially using
https://docs.rs/tokio/latest/tokio/task/struct.LocalSet.html
etc.