### PR TITLE
integrationtest: Properly thread `async` through to test helper

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -653,14 +653,14 @@ fn ima_sign(cmdopts: &ImaSignOpts) -> Result<()> {
 }
 
 #[cfg(feature = "internal-testing-api")]
-fn testing(opts: &TestingOpts) -> Result<()> {
+async fn testing(opts: &TestingOpts) -> Result<()> {
     match opts {
         TestingOpts::DetectEnv => {
             let s = crate::integrationtest::detectenv();
             println!("{}", s);
             Ok(())
         }
-        TestingOpts::CreateFixture => crate::integrationtest::create_fixture(),
+        TestingOpts::CreateFixture => crate::integrationtest::create_fixture().await,
         TestingOpts::Run => crate::integrationtest::run_tests(),
         TestingOpts::RunIMA => crate::integrationtest::test_ima(),
         TestingOpts::FilterTar => {
@@ -797,6 +797,6 @@ where
         },
         Opt::ImaSign(ref opts) => ima_sign(opts),
         #[cfg(feature = "internal-testing-api")]
-        Opt::InternalOnlyForTesting(ref opts) => testing(opts),
+        Opt::InternalOnlyForTesting(ref opts) => testing(opts).await,
     }
 }

--- a/lib/src/integrationtest.rs
+++ b/lib/src/integrationtest.rs
@@ -94,13 +94,9 @@ fn test_proxy_auth() -> Result<()> {
 /// Create a test fixture in the same way our unit tests does, and print
 /// the location of the temporary directory.  Also export a chunked image.
 /// Useful for debugging things interactively.
-pub(crate) fn create_fixture() -> Result<()> {
+pub(crate) async fn create_fixture() -> Result<()> {
     let fixture = crate::fixture::Fixture::new_v1()?;
-    let imgref = tokio::task::block_in_place(|| {
-        tokio::runtime::Handle::current()
-            .block_on(fixture.export_container())
-            .map(|v| v.0)
-    })?;
+    let imgref = fixture.export_container().await?.0;
     println!("Wrote: {:?}", imgref);
     let path = fixture.into_tempdir().into_path();
     println!("Wrote: {:?}", path);


### PR DESCRIPTION
In various places we're lazy about properly using async; e.g.
some of the test fixtures do a ton of blocking I/O.  None of that
really matters honestly as long as the *core* library does
things properly.

This bit of code in the test case was very hackily re-entering
the async context that we already have from `main`; but it only
works on the multithreaded tokio and we're aiming to switch to
single threaded.

That was just lazy of me; it was actually not at all hard to just
properly add a few `async fn` and `await`.