### PR TITLE
Port to cap-std 0.25, ostree 0.15, sh-inline 0.3

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,20 +17,20 @@ bitflags = "1"
 camino = "1.0.4"
 chrono = "0.4.19"
 cjson = "0.1.1"
-cap-std-ext = ">= 0.25"
-cap-tempfile = "0.24"
+cap-std-ext = "0.26"
+cap-tempfile = "0.25"
 flate2 = { features = ["zlib"], default_features = false, version = "1.0.20" }
 fn-error-context = "0.2.0"
 futures-util = "0.3.13"
 gvariant = "0.4.0"
 hex = "0.4.3"
 indicatif = "0.16.0"
-io-lifetimes = "0.5"
+io-lifetimes = "0.7"
 once_cell = "1.9"
 libc = "0.2.92"
 oci-spec = "0.5.4"
 openssl = "0.10.33"
-ostree = { features = ["v2021_5", "cap-std-apis"], version = "0.14.0" }
+ostree = { features = ["v2021_5", "cap-std-apis"], version = "0.15.0" }
 pin-project = "1.0"
 regex = "1.5.4"
 serde = { features = ["derive"], version = "1.0.125" }
@@ -45,7 +45,7 @@ tokio-stream = { features = ["sync"], version = "0.1.8" }
 tracing = "0.1"
 
 indoc = { version = "1.0.3", optional = true }
-sh-inline = { version = "0.2.2", features = ["cap-std-ext"], optional = true }
+sh-inline = { version = "0.3", features = ["cap-std-ext"], optional = true }
 
 [dev-dependencies]
 quickcheck = "1"

--- a/lib/src/fixture.rs
+++ b/lib/src/fixture.rs
@@ -369,7 +369,7 @@ impl Fixture {
         srcdir_dfd.create_dir("gpghome")?;
         let gpghome = srcdir_dfd.open_dir("gpghome")?;
         let st = std::process::Command::new("tar")
-            .cwd_dir_owned(gpghome)
+            .cwd_dir(gpghome)
             .stdin(Stdio::from(gpgtar))
             .args(&["-azxf", "-"])
             .status()?;

--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -403,8 +403,6 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
         let path = object_path(ostree::ObjectType::File, checksum);
 
         let (instream, meta, xattrs) = self.repo.load_file(checksum, gio::NONE_CANCELLABLE)?;
-        let meta = meta.ok_or_else(|| anyhow!("Missing metadata for object {}", checksum))?;
-        let xattrs = xattrs.ok_or_else(|| anyhow!("Missing xattrs for object {}", checksum))?;
 
         let mut h = tar::Header::new_gnu();
         h.set_uid(meta.attribute_uint32("unix::uid") as u64);


### PR DESCRIPTION


Our semver train is fun; updating cap-std for us involves a semver
bump for ostree because it exports public types from that.

We also have our utility crate `cap-std-ext` in the mix that needs
bumping.  And we have `sh-inline` which depends on all this.

I had to bump semver for all those at once.  I'm now regretting
`sh-inline`'s existence, or at least its dependency on cap-std.

---

