### PR TITLE
tests: Expose `ocidir`, but only when testing

### DIFF
--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -238,8 +238,10 @@ pub use unencapsulate::*;
 // But that isn't turned on for other crates that use this, and correctly gating all
 // of it is a little tedious.  So let's just use the big hammer for now to
 // quiet the dead code warnings.
-#[allow(dead_code)]
-pub(crate) mod ocidir;
+#[cfg(feature = "internal-testing-api")]
+pub mod ocidir;
+#[cfg(not(feature = "internal-testing-api"))]
+mod ocidir;
 mod skopeo;
 pub mod store;
 mod update_detachedmeta;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -52,3 +52,5 @@ pub mod prelude {
 pub mod fixture;
 #[cfg(feature = "internal-testing-api")]
 pub mod integrationtest;
+#[cfg(feature = "internal-testing-api")]
+pub use container::ocidir;


### PR DESCRIPTION
I want to do some more unit-test-style validation of our exported
container images.  Now, we could have the tests directly
use the [imageproxy][imageproxy] but it's very async-oriented
which is heavy for the tests.

[imageproxy]: https://github.com/containers/containers-image-proxy-rs