### PR TITLE
chunked: Include all directories

### DIFF
--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -306,7 +306,10 @@ fn validate_tar_v1<R: std::io::Read>(mut src: tar::Archive<R>) -> Result<()> {
     .into_iter()
     .map(Into::into);
 
-    let expected = prelude.chain(common_tar_structure());
+    let content = [("usr", Directory, 0o755), ("boot", Directory, 0o755)];
+    let content = content.into_iter().map(Into::into);
+
+    let expected = prelude.chain(common_tar_structure()).chain(content);
     validate_tar_expected(1, src.entries()?, expected)?;
 
     Ok(())


### PR DESCRIPTION
Depends:

- https://github.com/ostreedev/ostree-rs-ext/pull/327
- https://github.com/ostreedev/ostree-rs-ext/pull/326

---

tests: Validate structure of chunked image ostree layer

Chunked images are format v1 tar; let's add some unit-test style
code that validates the tar structure there in the same way we
verify direct tar exports.

Prep for fixing https://github.com/ostreedev/ostree-rs-ext/issues/309

---

chunking: Include all directories in ostree layer

This is prep for fixing https://github.com/ostreedev/ostree-rs-ext/issues/309
but it will not fix it on its own; to do that we need to introduce
a new chunked format.  That is forthcoming.

In the default tar export, we walk a commit from the "root".  When
exporting chunked images (what will soon be called "chunkedv0")
we instead export content objects, then a final layer which
contains the ostree metadata (commit and dirtree/dirmeta).

But in that "chunkedv0" flow, nothing creates the *tar* equivalent
of directories.  This has a number of problems; primarily it will
implicitly omit any directories which do not have content in them
(for example `/tmp`).  We also won't have the proper ownership/directories
reflected in the tar stream.

In this commit, change how we generate the "ostree layer" which
contains the ostree metadata to walk from the ostree-commit
as a root; except we just don't emit any content objects in that
flow to start, assuming they were emitted earlier.

(It is common for chunkedv0 images to have content objects, they
 are just emitted as a second phase)

Note that we no longer need to gather all metadata objects when
processing chunking, because we'll end up walking everything in
the export phase instead.

---

