### PR TITLE
tar/export: Drop a leftover `dbg!`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,8 @@ jobs:
     container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
     steps:
       - uses: actions/checkout@v2
+      - name: Code lints
+        run: ./ci/lints.sh
       - name: Install deps
         run: ./ci/installdeps.sh
       # xref containers/containers-image-proxy-rs

--- a/ci/lints.sh
+++ b/ci/lints.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+tmpf=$(mktemp)
+git grep 'dbg!' '*.rs' > ${tmpf} || true
+if test -s ${tmpf}; then
+    echo "Found dbg!" 1>&2
+    cat "${tmpf}"
+    exit 1
+fi

--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -699,7 +699,6 @@ pub(crate) fn reinject_detached_metadata<C: IsA<gio::Cancellable>>(
     let next_ent_path: &Utf8Path = (&*next_ent_path).try_into()?;
     let objtype = crate::tar::import::Importer::parse_metadata_entry(next_ent_path)?.1;
     if objtype != ostree::ObjectType::CommitMeta {
-        dbg!(objtype);
         crate::tar::write::copy_entry(next_ent, dest, None)?;
     }
 


### PR DESCRIPTION
tar/export: Drop a leftover `dbg!`

Oops.

---

ci: Add a custom lint check for leftover `dbg!`

It's tempting to add this to clippy.

---

