### PR TITLE
container: Introduce an `ExportLayout::ChunkedV1`

### DIFF
--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -31,8 +31,10 @@ use std::ops::Deref;
 
 /// The label injected into a container image that contains the ostree commit SHA-256.
 pub const OSTREE_COMMIT_LABEL: &str = "ostree.commit";
-/// The label/annotation which contains the sha256 of the final commit.
+/// The label/annotation which contains the sha256 of the final commit in chunked v1 format.
 const OSTREE_DIFFID_LABEL: &str = "ostree.diffid";
+/// The label/annotation which contains the sha256 of the final layer in chunked v2 format.
+const OSTREE_FINAL_LAYER_LABEL: &str = "ostree.final-diffid";
 
 /// Our generic catchall fatal error, expected to be converted
 /// to a string to output to a terminal or logs.

--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -31,10 +31,6 @@ use std::ops::Deref;
 
 /// The label injected into a container image that contains the ostree commit SHA-256.
 pub const OSTREE_COMMIT_LABEL: &str = "ostree.commit";
-/// The label/annotation which contains the sha256 of the final commit in chunked v1 format.
-const OSTREE_DIFFID_LABEL: &str = "ostree.diffid";
-/// The label/annotation which contains the sha256 of the final layer in chunked v2 format.
-const OSTREE_FINAL_LAYER_LABEL: &str = "ostree.final-diffid";
 
 /// Our generic catchall fatal error, expected to be converted
 /// to a string to output to a terminal or logs.

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -10,6 +10,7 @@ use crate::refescape;
 use anyhow::{anyhow, Context};
 use containers_image_proxy::{ImageProxy, OpenedImage};
 use fn_error_context::context;
+use futures_util::TryFutureExt;
 use oci_spec::image::{self as oci_image, Descriptor, History, ImageConfiguration, ImageManifest};
 use ostree::prelude::{Cast, ToVariant};
 use ostree::{gio, glib};
@@ -170,6 +171,9 @@ impl ManifestLayerState {
 /// Information about which layers need to be downloaded.
 #[derive(Debug)]
 pub struct PreparedImport {
+    /// The format we found from metadata
+    #[allow(dead_code)]
+    pub(crate) export_layout: ExportLayout,
     /// The manifest digest that was found
     pub manifest_digest: String,
     /// The deserialized manifest.
@@ -295,21 +299,88 @@ fn layer_from_diffid<'a>(
     })
 }
 
-pub(crate) fn ostree_layer<'a>(
+pub(crate) fn parse_manifest_layout<'a>(
     manifest: &'a ImageManifest,
     config: &ImageConfiguration,
-) -> Result<&'a Descriptor> {
-    let label = crate::container::OSTREE_DIFFID_LABEL;
+) -> Result<(
+    ExportLayout,
+    &'a Descriptor,
+    Vec<&'a Descriptor>,
+    Vec<&'a Descriptor>,
+)> {
     let config_labels = config.config().as_ref().and_then(|c| c.labels().as_ref());
-    let diffid = config_labels.and_then(|labels| labels.get(label));
-    // For backwards compatibility, if there's only 1 layer, don't require the label.
+
+    let first_layer = manifest
+        .layers()
+        .get(0)
+        .ok_or_else(|| anyhow!("No layers in manifest"))?;
+    let info = config_labels.and_then(|labels| {
+        labels
+            .get(OSTREE_FINAL_LAYER_LABEL)
+            .map(|v| (ExportLayout::ChunkedV1, v))
+            .or_else(|| {
+                labels
+                    .get(OSTREE_DIFFID_LABEL)
+                    .map(|v| (ExportLayout::ChunkedV0, v))
+            })
+    });
+
+    // Look for the format v1 label
+    if let Some((layout, target_diffid)) = info {
+        let target_layer = layer_from_diffid(manifest, config, target_diffid.as_str())?;
+        let mut chunk_layers = Vec::new();
+        let mut derived_layers = Vec::new();
+        let mut after_target = false;
+        // Gather the ostree layer
+        let ostree_layer = match layout {
+            ExportLayout::SingleLayer | ExportLayout::ChunkedV0 => target_layer,
+            ExportLayout::ChunkedV1 => first_layer,
+        };
+        // Now, we need to handle the split differently in chunked v1 vs v0
+        match layout {
+            ExportLayout::SingleLayer | ExportLayout::ChunkedV0 => {
+                for layer in manifest.layers() {
+                    if layer == target_layer {
+                        if after_target {
+                            anyhow::bail!("Multiple entries for {}", layer.digest());
+                        }
+                        after_target = true;
+                    } else if !after_target {
+                        chunk_layers.push(layer);
+                    } else {
+                        derived_layers.push(layer);
+                    }
+                }
+            }
+            ExportLayout::ChunkedV1 => {
+                for layer in manifest.layers() {
+                    if layer == target_layer {
+                        if after_target {
+                            anyhow::bail!("Multiple entries for {}", layer.digest());
+                        }
+                        after_target = true;
+                        if layer != ostree_layer {
+                            chunk_layers.push(layer);
+                        }
+                    } else if !after_target {
+                        if layer != ostree_layer {
+                            chunk_layers.push(layer);
+                        }
+                    } else {
+                        derived_layers.push(layer);
+                    }
+                }
+            }
+        }
+
+        let r = (layout, ostree_layer, chunk_layers, derived_layers);
+        return Ok(r);
+    }
+
+    // For backwards compatibility, if there's only 1 layer, don't require labels.
     // This can be dropped when we drop format version 0 support.
-    let r = if let Some(diffid) = diffid {
-        layer_from_diffid(manifest, config, diffid.as_str())?
-    } else {
-        &manifest.layers()[0]
-    };
-    Ok(r)
+    let rest = manifest.layers().iter().skip(1).collect();
+    Ok((ExportLayout::SingleLayer, first_layer, Vec::new(), rest))
 }
 
 impl ImageImporter {
@@ -404,29 +475,22 @@ impl ImageImporter {
 
         let config = self.proxy.fetch_config(&self.proxy_img).await?;
 
-        let commit_layer_digest = ostree_layer(&manifest, &config)?.digest();
+        let (export_layout, commit_layer, component_layers, remaining_layers) =
+            parse_manifest_layout(&manifest, &config)?;
 
-        let mut component_layers = Vec::new();
-        let mut commit_layer = None;
-        let mut remaining_layers = Vec::new();
         let query = |l: &Descriptor| query_layer(&self.repo, l.clone());
-        for layer in manifest.layers() {
-            if layer.digest() == commit_layer_digest {
-                commit_layer = Some(query(layer)?);
-            } else if commit_layer.is_none() {
-                component_layers.push(query(layer)?);
-            } else {
-                remaining_layers.push(query(layer)?);
-            }
-        }
-        let commit_layer = commit_layer.ok_or_else(|| {
-            anyhow!(
-                "Image does not contain ostree-exported layer {}",
-                commit_layer_digest
-            )
-        })?;
+        let commit_layer = query(commit_layer)?;
+        let component_layers = component_layers
+            .into_iter()
+            .map(query)
+            .collect::<Result<Vec<_>>>()?;
+        let remaining_layers = remaining_layers
+            .into_iter()
+            .map(query)
+            .collect::<Result<Vec<_>>>()?;
 
         let imp = PreparedImport {
+            export_layout,
             manifest,
             manifest_digest,
             config,
@@ -493,7 +557,8 @@ impl ImageImporter {
                     };
                     txn.commit(Some(cancellable))?;
                     Ok::<_, anyhow::Error>(commit)
-                });
+                })
+                .map_err(|e| e.context(format!("Layer {}", layer.digest())));
             let commit = super::unencapsulate::join_fetch(import_task, driver).await?;
             layer.commit = commit;
             if let Some(p) = self.layer_progress.as_ref() {

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -172,8 +172,7 @@ impl ManifestLayerState {
 #[derive(Debug)]
 pub struct PreparedImport {
     /// The format we found from metadata
-    #[allow(dead_code)]
-    pub(crate) export_layout: ExportLayout,
+    pub export_layout: ExportLayout,
     /// The manifest digest that was found
     pub manifest_digest: String,
     /// The deserialized manifest.

--- a/lib/src/container/update_detachedmeta.rs
+++ b/lib/src/container/update_detachedmeta.rs
@@ -1,5 +1,5 @@
 use super::ImageReference;
-use crate::container::{ocidir, skopeo};
+use crate::container::{ocidir, skopeo, ExportLayout};
 use crate::container::{store as container_store, Transport};
 use anyhow::{anyhow, Context, Result};
 use camino::Utf8Path;
@@ -61,7 +61,8 @@ pub async fn update_detached_metadata(
             .ok_or_else(|| anyhow!("Image is missing container configuration"))?;
 
         // Find the OSTree commit layer we want to replace
-        let commit_layer = container_store::ostree_layer(&manifest, &config)?;
+        let (export_layout, commit_layer, _, _) =
+            container_store::parse_manifest_layout(&manifest, &config)?;
         let commit_layer_idx = manifest
             .layers()
             .iter()
@@ -102,10 +103,24 @@ pub async fn update_detached_metadata(
         config.rootfs_mut().diff_ids_mut()[commit_layer_idx] = out_layer_diffid.clone();
 
         let labels = ctrcfg.labels_mut().get_or_insert_with(Default::default);
-        labels.insert(
-            crate::container::OSTREE_DIFFID_LABEL.into(),
-            out_layer_diffid,
-        );
+        match export_layout {
+            ExportLayout::SingleLayer | ExportLayout::ChunkedV0 => {
+                labels.insert(
+                    crate::container::OSTREE_DIFFID_LABEL.into(),
+                    out_layer_diffid,
+                );
+            }
+            ExportLayout::ChunkedV1 => {
+                // Nothing to do except in the special case where there's somehow only one
+                // chunked layer.
+                if manifest.layers().len() == 1 {
+                    labels.insert(
+                        crate::container::OSTREE_FINAL_LAYER_LABEL.into(),
+                        out_layer_diffid,
+                    );
+                }
+            }
+        }
         config.set_config(Some(ctrcfg));
 
         // Write the config and manifest

--- a/lib/src/container/update_detachedmeta.rs
+++ b/lib/src/container/update_detachedmeta.rs
@@ -104,20 +104,14 @@ pub async fn update_detached_metadata(
 
         let labels = ctrcfg.labels_mut().get_or_insert_with(Default::default);
         match export_layout {
-            ExportLayout::SingleLayer | ExportLayout::ChunkedV0 => {
-                labels.insert(
-                    crate::container::OSTREE_DIFFID_LABEL.into(),
-                    out_layer_diffid,
-                );
+            ExportLayout::V0 => {
+                labels.insert(export_layout.label().into(), out_layer_diffid);
             }
-            ExportLayout::ChunkedV1 => {
+            ExportLayout::V1 => {
                 // Nothing to do except in the special case where there's somehow only one
                 // chunked layer.
                 if manifest.layers().len() == 1 {
-                    labels.insert(
-                        crate::container::OSTREE_FINAL_LAYER_LABEL.into(),
-                        out_layer_diffid,
-                    );
+                    labels.insert(export_layout.label().into(), out_layer_diffid);
                 }
             }
         }

--- a/lib/src/fixture.rs
+++ b/lib/src/fixture.rs
@@ -3,7 +3,7 @@
 #![allow(missing_docs)]
 
 use crate::chunking::ObjectMetaSized;
-use crate::container::{Config, ExportOpts, ImageReference, Transport};
+use crate::container::{Config, ExportLayout, ExportOpts, ImageReference, Transport};
 use crate::objectsource::{ObjectMeta, ObjectSourceMeta};
 use crate::prelude::*;
 use crate::{gio, glib};
@@ -606,8 +606,16 @@ impl Fixture {
     /// Export the current ref as a container image.
     /// This defaults to using chunking.
     #[context("Exporting container")]
-    pub async fn export_container(&self) -> Result<(ImageReference, String)> {
-        let container_path = &self.path.join("oci");
+    pub async fn export_container(
+        &self,
+        export_format: ExportLayout,
+    ) -> Result<(ImageReference, String)> {
+        let name = match export_format {
+            ExportLayout::SingleLayer => "oci-single",
+            ExportLayout::ChunkedV0 => "oci-chunked-v0",
+            ExportLayout::ChunkedV1 => "oci-chunked-v1",
+        };
+        let container_path = &self.path.join(name);
         if container_path.exists() {
             std::fs::remove_dir_all(container_path)?;
         }
@@ -627,7 +635,10 @@ impl Fixture {
         let contentmeta = self.get_object_meta().context("Computing object meta")?;
         let contentmeta = ObjectMetaSized::compute_sizes(self.srcrepo(), contentmeta)
             .context("Computing sizes")?;
-        let opts = ExportOpts::default();
+        let opts = ExportOpts {
+            format: export_format,
+            ..Default::default()
+        };
         let digest = crate::container::encapsulate(
             self.srcrepo(),
             self.testref(),

--- a/lib/src/fixture.rs
+++ b/lib/src/fixture.rs
@@ -611,9 +611,8 @@ impl Fixture {
         export_format: ExportLayout,
     ) -> Result<(ImageReference, String)> {
         let name = match export_format {
-            ExportLayout::SingleLayer => "oci-single",
-            ExportLayout::ChunkedV0 => "oci-chunked-v0",
-            ExportLayout::ChunkedV1 => "oci-chunked-v1",
+            ExportLayout::V0 => "oci-v0",
+            ExportLayout::V1 => "oci-v1",
         };
         let container_path = &self.path.join(name);
         if container_path.exists() {

--- a/lib/src/integrationtest.rs
+++ b/lib/src/integrationtest.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use crate::container::ocidir;
+use crate::container::{ocidir, ExportLayout};
 use anyhow::Result;
 use camino::Utf8Path;
 use cap_std::fs::Dir;
@@ -96,8 +96,10 @@ fn test_proxy_auth() -> Result<()> {
 /// Useful for debugging things interactively.
 pub(crate) async fn create_fixture() -> Result<()> {
     let fixture = crate::fixture::Fixture::new_v1()?;
-    let imgref = fixture.export_container().await?.0;
-    println!("Wrote: {:?}", imgref);
+    for format in [ExportLayout::ChunkedV0, ExportLayout::ChunkedV1] {
+        let imgref = fixture.export_container(format).await?.0;
+        println!("Wrote: {:?}", imgref);
+    }
     let path = fixture.into_tempdir().into_path();
     println!("Wrote: {:?}", path);
     Ok(())

--- a/lib/src/integrationtest.rs
+++ b/lib/src/integrationtest.rs
@@ -96,7 +96,7 @@ fn test_proxy_auth() -> Result<()> {
 /// Useful for debugging things interactively.
 pub(crate) async fn create_fixture() -> Result<()> {
     let fixture = crate::fixture::Fixture::new_v1()?;
-    for format in [ExportLayout::ChunkedV0, ExportLayout::ChunkedV1] {
+    for format in [ExportLayout::V0, ExportLayout::V1] {
         let imgref = fixture.export_container(format).await?.0;
         println!("Wrote: {:?}", imgref);
     }

--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -626,7 +626,7 @@ pub(crate) fn export_chunk<W: std::io::Write>(
 pub(crate) fn export_final_chunk<W: std::io::Write>(
     repo: &ostree::Repo,
     commit_checksum: &str,
-    chunking: chunking::Chunking,
+    remainder: chunking::Chunk,
     out: &mut tar::Builder<W>,
 ) -> Result<()> {
     // For chunking, we default to format version 1
@@ -641,7 +641,7 @@ pub(crate) fn export_final_chunk<W: std::io::Write>(
     writer.structure_only = true;
     writer.write_commit()?;
     writer.structure_only = false;
-    write_chunk(writer, chunking.remainder.content)
+    write_chunk(writer, remainder.content)
 }
 
 /// Process an exported tar stream, and update the detached metadata.

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -674,6 +674,7 @@ async fn impl_test_container_chunked(format: ExportLayout) -> Result<()> {
         store::PrepareResult::AlreadyPresent(_) => panic!("should not be already imported"),
         store::PrepareResult::Ready(r) => r,
     };
+    assert_eq!(prep.export_layout, format);
     let digest = prep.manifest_digest.clone();
     assert!(prep.ostree_commit_layer.commit.is_none());
     assert_eq!(prep.ostree_layers.len(), nlayers as usize);


### PR DESCRIPTION
Depends: https://github.com/ostreedev/ostree-rs-ext/pull/328

---
container: Introduce an `ExportLayout::ChunkedV1`

Closes: https://github.com/ostreedev/ostree-rs-ext/issues/309

I discovered that (what are now called) "chunkedv0" images were missing some
directories like `/tmp`.  This is because the way chunking was implemented
was...basically broken.

In chunking v0 we have:

- content objects
- content objects
- ...
- ostree layer (commit, ostree metadata)
- Any derived layers

But...we really want to "mirror" in the tar stream in a proper
fashion everything that's in the ostree layer. Particularly, in order
to ensure e.g. correct permissions/ownership, the directory entries
must come first.

And logically, it makes sense to have the layer bearing the ostree
commit and the ostree metadata come first.

So the new "ChunkedV1" format is:

- ostree layer (commit, ostree metadata, all directories_
- content objects
- content objects
- ...
- Any derived layers

The ChunkedV1 format can be identified by a new image label:
`const OSTREE_FINAL_LAYER_LABEL: &str = "ostree.final-diffid";`
this label points to the last content object layer.

Implementation wise, this is mostly adding conditionals in
various places.

I'm perhaps being very conservative here in *also* continuing to
support 'chunkedv0 images.  Right now they're not deployed
widely (AFAIK), just shipping Fedora Rawhide this way.

But on the plus side, we'll be able to kill off all the old format
code when this stuff is all stable.

---

container: Condense `ExportLayout` to just V0 and V1

I had a galaxy brain moment earlier today when looking at this PR;
a lot of the matching was doing `SingleLayer | ChunkedV1`.  Everything
just gets simpler if we consider the "single layer" a special case
of a "chunked" image with a single chunk - which we already support!

In the export code, if no content mapping is provided we create
a default chunking.  (This can and should be optimized later to
avoid traversing all objects up front; we can special case this)

Another way to look at this is that the change in the export side
from the tar stream perspective is that we now have:

- all directories and ostree metadata
- all content objects in hash ordering

And here's a key bit: The old (<= ostree-ext 0.7) tar parser
will still parse this just fine - it doesn't currently care about
object ordering.  And the same is true for container runtimes.

---

container: Make `export_layout` bit in prepared import `pub`

Right now we're not using it, but I think we should support
callers e.g. logging it at least.

---

