### PR TITLE
lib/container: `#[allow(dead_code)]` for ocidir

### DIFF
--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -241,6 +241,7 @@ pub use unencapsulate::*;
 #[cfg(feature = "internal-testing-api")]
 pub mod ocidir;
 #[cfg(not(feature = "internal-testing-api"))]
+#[allow(dead_code)]
 mod ocidir;
 mod skopeo;
 pub mod store;


### PR DESCRIPTION
When compiling from an external crate, dead code analysis hits
a few things that we don't currently use.