### PR TITLE
Move `io-std` tokio feature into `lib`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,8 @@ jobs:
           key: "tests"
       - name: Build
         run: cargo test --no-run
+      - name: Individual checks
+        run: (cd cli && cargo check) && (cd lib && cargo check)
       - name: Run tests
         run: cargo test -- --nocapture --quiet
   build:

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,7 +13,7 @@ ostree-ext = { path = "../lib" }
 clap = "2.33.3"
 structopt = "0.3.21"
 libc = "0.2.92"
-tokio = { version = "1", features = ["io-std", "macros"] }
+tokio = { version = "1", features = ["macros"] }
 log = "0.4.0"
 tracing = "0.1"
 tracing-subscriber = "0.2.17"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -39,7 +39,7 @@ structopt = "0.3.21"
 tar = "0.4.38"
 tempfile = "3.2.0"
 term_size = "0.3.2"
-tokio = { features = ["time", "process", "rt", "net"], version = ">= 1.13.0" }
+tokio = { features = ["io-std", "time", "process", "rt", "net"], version = ">= 1.13.0" }
 tokio-util = { features = ["io-util"], version = "0.6.9" }
 tokio-stream = { features = ["sync"], version = "0.1.8" }
 tracing = "0.1"


### PR DESCRIPTION
Our project is a workspace, and `cargo build` will build both `cli/`
and `lib/`.  Feature unification means the build gets all tokio
features.

But, I want trying to use the rust-analyzer ability to run an
individual test, and that broke with the recent tokio feature
cleanup because we're trying to just build the library, which
actually does need `io-std`.

(For us, all the code for the CLI is in the library)

So move the feature there, and add CI covers individual builds.