### PR TITLE
tests: Prep for fixing identical subdirectory export

### DIFF
--- a/lib/src/fixture.rs
+++ b/lib/src/fixture.rs
@@ -131,6 +131,8 @@ static OWNERS: Lazy<Vec<(Regex, &str)>> = Lazy::new(|| {
         ("usr/bin/hardlink.*", "testlink"),
         ("usr/etc/someconfig.conf", "someconfig"),
         ("usr/etc/polkit.conf", "a-polkit-config"),
+        ("usr/lib/pkgdb", "pkgdb"),
+        ("usr/lib/sysimage/pkgdb", "pkgdb"),
     ]
     .iter()
     .map(|(k, v)| (Regex::new(k).unwrap(), *v))
@@ -150,6 +152,10 @@ r usr/bin/hardlink-b testlink
 r usr/etc/someconfig.conf someconfig
 m 10 10 644
 r usr/etc/polkit.conf a-polkit-config
+m 0 0 644
+# See https://github.com/coreos/fedora-coreos-tracker/issues/1258
+r usr/lib/sysimage/pkgdb some-package-database
+r usr/lib/pkgdb/pkgdb some-package-database
 m
 d boot
 d run
@@ -157,7 +163,8 @@ m 0 0 1755
 d tmp
 "## };
 pub const CONTENTS_CHECKSUM_V0: &str =
-    "76f0d5ec8814bc2a1d7868dbe8d3783535dc0cc9c7dcfdf37fa3512f8e276f6c";
+    "3af747e156c34d08a3a2fb85b94de6999205a1d1c1c7b1993d6ce534a8918cd9";
+pub static CONTENTS_V0_LEN: Lazy<usize> = Lazy::new(|| OWNERS.len());
 
 #[derive(Debug, PartialEq, Eq)]
 enum SeLabel {

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -248,6 +248,7 @@ fn validate_tar_expected<T: std::io::Read>(
             assert_eq!(header.entry_type(), exp.etype, "{}", entry_path);
             let is_old_object = format_version == 0;
             let mut expected_mode = exp.mode;
+            let header_mode = header.mode().unwrap();
             if is_old_object && !entry_path.starts_with("sysroot/") {
                 let fmtbits = match header.entry_type() {
                     tar::EntryType::Regular => libc::S_IFREG,
@@ -258,9 +259,9 @@ fn validate_tar_expected<T: std::io::Read>(
                 expected_mode |= fmtbits;
             }
             assert_eq!(
-                header.mode().unwrap(),
+                header_mode,
                 expected_mode,
-                "fmtver: {} type: {:?} path: {}",
+                "h={header_mode:o} e={expected_mode:o} fmtver: {} type: {:?} path: {}",
                 format_version,
                 header.entry_type(),
                 entry_path


### PR DESCRIPTION
tests: Emit expected modes in octal

Easier to read this way.

---

tests: Add two subdirectories with identical content

Prep for fixing https://github.com/coreos/fedora-coreos-tracker/issues/1258

---

tests: Pass tar entries by reference

Prep for testing the full tar export vs chunked container paths
better.

---

tests: More refactoring of expected tar handling

Add a missing 'return Ok(())` so we can split the tar stream validation
to do:

- validate prelude
- validate contents

We were also missing validation for content objects before, so fix
that!

The chunked container path in particular will need to handle content
validation differently from the "all in one" tarball.

---

tests: Verify at least one pkgdb entry is there

Prep for fixing https://github.com/ostreedev/ostree-rs-ext/issues/339

---

