### PR TITLE
deny: Allowlist `Unicode-DFS-2016`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,6 @@
 [licenses]
 unlicensed = "deny"
-allow = ["Apache-2.0", "Apache-2.0 WITH LLVM-exception", "MIT", "BSD-3-Clause", "BSD-2-Clause"]
+allow = ["Apache-2.0", "Apache-2.0 WITH LLVM-exception", "MIT", "BSD-3-Clause", "BSD-2-Clause", "Unicode-DFS-2016"]
 
 [bans]
 


### PR DESCRIPTION
See https://github.com/dtolnay/unicode-ident/pull/9
This is a FOSS license, see e.g.
https://fedoraproject.org/wiki/Licensing/Unicode