### PR TITLE
 container: Use tar format v1 for container chunks too

### DIFF
--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -616,7 +616,13 @@ pub(crate) fn export_chunk<W: std::io::Write>(
     chunk: chunking::ChunkMapping,
     out: &mut tar::Builder<W>,
 ) -> Result<()> {
-    let writer = &mut OstreeTarWriter::new(repo, commit, out, ExportOptions::default())?;
+    // For chunking, we default to format version 1
+    #[allow(clippy::needless_update)]
+    let opts = ExportOptions {
+        format_version: 1,
+        ..Default::default()
+    };
+    let writer = &mut OstreeTarWriter::new(repo, commit, out, opts)?;
     writer.write_repo_structure()?;
     write_chunk(writer, chunk)
 }

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -688,7 +688,7 @@ fn validate_chunked_structure(oci_path: &Utf8Path, format: ExportLayout) -> Resu
     .into_iter()
     .map(Into::into);
 
-    validate_tar_expected(0, &mut pkgdb_blob.entries()?, pkgdb)?;
+    validate_tar_expected(1, &mut pkgdb_blob.entries()?, pkgdb)?;
 
     Ok(())
 }


### PR DESCRIPTION
Depends https://github.com/ostreedev/ostree-rs-ext/pull/338

---

container: Use tar format v1 for container chunks too

Amazingly while I was working on a different bug
I stumbled across the fact that the chunked path was using format v0
tar streams.

Fix that.
