### PR TITLE
lib: port CLI handling to clap v3

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,8 +10,7 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0"
 ostree-ext = { path = "../lib" }
-clap = "2.33.3"
-structopt = "0.3.21"
+clap = "3.2"
 libc = "0.2.92"
 tokio = { version = "1", features = ["macros"] }
 log = "0.4.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -11,12 +11,12 @@ version = "0.8.7"
 [dependencies]
 anyhow = "1.0"
 containers-image-proxy = "0.5.1"
-
 async-compression = { version = "0.3", features = ["gzip", "tokio"] }
 bitflags = "1"
 camino = "1.0.4"
 chrono = "0.4.19"
 cjson = "0.1.1"
+clap = { version= "3.2", features = ["derive"] }
 cap-std-ext = "0.26"
 cap-tempfile = "0.25"
 flate2 = { features = ["zlib"], default_features = false, version = "1.0.20" }
@@ -34,7 +34,6 @@ pin-project = "1.0"
 regex = "1.5.4"
 serde = { features = ["derive"], version = "1.0.125" }
 serde_json = "1.0.64"
-structopt = "0.3.21"
 tar = "0.4.38"
 tempfile = "3.2.0"
 term_size = "0.3.2"

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -43,7 +43,7 @@ static TEST_REGISTRY: Lazy<String> = Lazy::new(|| match std::env::var_os("TEST_R
 fn test_cli_fns() -> Result<()> {
     let fixture = Fixture::new_v1()?;
     let srcpath = fixture.path.join("src/repo");
-    let srcrepo_parsed = ostree_ext::cli::parse_repo(srcpath.as_str()).unwrap();
+    let srcrepo_parsed = ostree_ext::cli::parse_repo(&srcpath).unwrap();
     assert_eq!(srcrepo_parsed.mode(), fixture.srcrepo().mode());
 
     let ir =


### PR DESCRIPTION
This reworks CLI handling logic, porting to latest clap v3.

Closes: https://github.com/ostreedev/ostree-rs-ext/issues/373