### PR TITLE
cli: Don't panic on errors from unencapsulation

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -480,12 +480,12 @@ async fn container_import(
         pb
     });
     let importer = ImageImporter::new(repo, imgref, Default::default()).await?;
-    let import_result = importer.unencapsulate().await;
+    let import = importer.unencapsulate().await;
+    // Ensure we finish the progress bar before potentially propagating an error
     if let Some(pb) = pb.as_ref() {
         pb.finish();
     }
-    // It must have been set
-    let import = import_result.unwrap();
+    let import = import?;
     if let Some(write_ref) = write_ref {
         repo.set_ref_immediate(
             None,


### PR DESCRIPTION
I hit this when doing
`ostree-ext-cli container unencapsulate --repo=tmp/repo ostree-remote-registry:fedora:quay.io/coreos-assembler/fcos:testing-devel`
without a configured `fedora` remote.