### PR TITLE
lib: Extend clippy lints to deny `dbg!` and `todo!`

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -10,6 +10,8 @@
 #![forbid(unused_must_use)]
 #![deny(unsafe_code)]
 #![cfg_attr(feature = "dox", feature(doc_cfg))]
+#![deny(clippy::dbg_macro)]
+#![deny(clippy::todo)]
 
 // Re-export our dependencies.  See https://gtk-rs.org/blog/2021/06/22/new-release.html
 // "Dependencies are re-exported".  Users will need e.g. `gio::File`, so this avoids


### PR DESCRIPTION
xref https://github.com/rust-lang/rust-clippy/issues/9260