### PR TITLE
cli: Add `container encapsulate --compression-fast`

### DIFF
--- a/lib/src/container/encapsulate.rs
+++ b/lib/src/container/encapsulate.rs
@@ -344,7 +344,7 @@ impl ExportOpts {
     /// Return the gzip compression level to use, as configured by the export options.
     fn compression(&self) -> Compression {
         if self.skip_compression {
-            Compression::none()
+            Compression::fast()
         } else {
             Compression::default()
         }


### PR DESCRIPTION
container: Make `skip_compression` really use gzip fast, not none

Not doing any compression at all is quite bad for tar streams
which have a ton of duplicate data.

---

cli: Add `container encapsulate --compression-fast`

For the use case of exporting to a temporary OCI directory, which
we in turn then want to push into `containers-storage:` which
is going to decompress it again.

This will be used for e.g.
https://github.com/coreos/rpm-ostree/issues/3900

---

