### PR TITLE
container: write `base` ref

### DIFF
--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -26,6 +26,8 @@ pub const FORMAT_VERSIONS: RangeInclusive<u32> = 0..=1;
 const SYSROOT: &str = "sysroot";
 // This way the default ostree -> sysroot/ostree symlink works.
 const OSTREEDIR: &str = "sysroot/ostree";
+// The ref added (under ostree/) in the exported OSTree repo pointing at the commit.
+const OSTREEREF: &str = "encapsulated";
 
 /// In v0 format, we use this relative path prefix.  I think I chose this by looking
 /// at the current Fedora base image tar stream.  However, several others don't do
@@ -320,6 +322,13 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
                 &commitmeta,
             )?;
         }
+
+        // and add the canonical ref
+        let path: Utf8PathBuf = format!("{}/repo/refs/heads/ostree", OSTREEDIR).into();
+        self.append_default_dir(&path)?;
+        let path: Utf8PathBuf =
+            format!("{}/repo/refs/heads/ostree/{}", OSTREEDIR, OSTREEREF).into();
+        self.append_default_data(Utf8Path::new(&path), self.commit_checksum.as_bytes())?;
         Ok(())
     }
 

--- a/lib/src/tar/import.rs
+++ b/lib/src/tar/import.rs
@@ -202,8 +202,8 @@ impl Importer {
             .ok_or_else(|| anyhow!("Invalid non-utf8 path {:?}", orig_path))?;
         // Ignore the regular non-object file hardlinks we inject
         if let Ok(path) = path.strip_prefix(REPO_PREFIX) {
-            // Filter out the repo config file
-            if path.file_name() == Some("config") {
+            // Filter out the repo config file and refs dir
+            if path.file_name() == Some("config") || path.starts_with("refs") {
                 return Ok(None);
             }
             let path = path.into();

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -322,6 +322,14 @@ fn validate_tar_v1_metadata<R: std::io::Read>(src: &mut tar::Entries<R>) -> Resu
     let prelude = [
         ("sysroot/ostree/repo", Directory, 0o755),
         ("sysroot/ostree/repo/config", Regular, 0o644),
+        ("sysroot/ostree/repo/refs", Directory, 0o755),
+        ("sysroot/ostree/repo/refs/heads", Directory, 0o755),
+        ("sysroot/ostree/repo/refs/heads/ostree", Directory, 0o755),
+        (
+            "sysroot/ostree/repo/refs/heads/ostree/encapsulated",
+            Regular,
+            0o644,
+        ),
     ]
     .into_iter()
     .map(Into::into);


### PR DESCRIPTION
Although the OSTree commit checksum is in a label on the container
image, sometimes we need to be able to inspect the commit from within
the container itself.

Rather than forcing tools to look through the whole repo for a commit
object, write a canonical `base` ref pointing to it.

Related: https://github.com/ostreedev/ostree/pull/2691