### PR TITLE
container: Add an API to fetch both manifest and config

### DIFF
--- a/lib/src/container/unencapsulate.rs
+++ b/lib/src/container/unencapsulate.rs
@@ -112,6 +112,22 @@ pub async fn fetch_manifest(
     fetch_manifest_impl(&mut proxy, imgref).await
 }
 
+/// Download the manifest for a target image and its sha256 digest, as well as the image configuration.
+#[context("Fetching manifest and config")]
+pub async fn fetch_manifest_and_config(
+    imgref: &OstreeImageReference,
+) -> Result<(
+    oci_spec::image::ImageManifest,
+    String,
+    oci_spec::image::ImageConfiguration,
+)> {
+    let proxy = ImageProxy::new().await?;
+    let oi = &proxy.open_image(&imgref.imgref.to_string()).await?;
+    let (digest, manifest) = proxy.fetch_manifest(oi).await?;
+    let config = proxy.fetch_config(oi).await?;
+    Ok((manifest, digest, config))
+}
+
 /// The result of an import operation
 #[derive(Debug)]
 pub struct Import {

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -589,6 +589,10 @@ async fn impl_test_container_import_export(
     let (_, pushed_digest) = ostree_ext::container::fetch_manifest(&srcoci_unverified).await?;
     assert_eq!(pushed_digest, digest);
 
+    let (_, pushed_digest, _config) =
+        ostree_ext::container::fetch_manifest_and_config(&srcoci_unverified).await?;
+    assert_eq!(pushed_digest, digest);
+
     // No remote matching
     let srcoci_unknownremote = OstreeImageReference {
         sigverify: SignatureSource::OstreeRemote("unknownremote".to_string()),


### PR DESCRIPTION
I plan to use this as part of implementing `rpm-ostree compose container`
for change detection.  Basically we want to get the inputhash from
the metadata/labels.