### PR TITLE
Release 0.8.3

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
-version = "0.8.2"
+version = "0.8.3"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION


This just includes a change to generate an `ostree/encapsulated`
ref in containers, and a new API to fetch both manifest and config.

---

