### PR TITLE
Revert writing `ostree/encapsulated` ref

### DIFF
--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -27,6 +27,7 @@ const SYSROOT: &str = "sysroot";
 // This way the default ostree -> sysroot/ostree symlink works.
 const OSTREEDIR: &str = "sysroot/ostree";
 // The ref added (under ostree/) in the exported OSTree repo pointing at the commit.
+#[allow(dead_code)]
 const OSTREEREF: &str = "encapsulated";
 
 /// In v0 format, we use this relative path prefix.  I think I chose this by looking
@@ -322,13 +323,6 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
                 &commitmeta,
             )?;
         }
-
-        // and add the canonical ref
-        let path: Utf8PathBuf = format!("{}/repo/refs/heads/ostree", OSTREEDIR).into();
-        self.append_default_dir(&path)?;
-        let path: Utf8PathBuf =
-            format!("{}/repo/refs/heads/ostree/{}", OSTREEDIR, OSTREEREF).into();
-        self.append_default_data(Utf8Path::new(&path), self.commit_checksum.as_bytes())?;
         Ok(())
     }
 

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -322,14 +322,6 @@ fn validate_tar_v1_metadata<R: std::io::Read>(src: &mut tar::Entries<R>) -> Resu
     let prelude = [
         ("sysroot/ostree/repo", Directory, 0o755),
         ("sysroot/ostree/repo/config", Regular, 0o644),
-        ("sysroot/ostree/repo/refs", Directory, 0o755),
-        ("sysroot/ostree/repo/refs/heads", Directory, 0o755),
-        ("sysroot/ostree/repo/refs/heads/ostree", Directory, 0o755),
-        (
-            "sysroot/ostree/repo/refs/heads/ostree/encapsulated",
-            Regular,
-            0o644,
-        ),
     ]
     .into_iter()
     .map(Into::into);


### PR DESCRIPTION
This partially reverts 30dee81c22ad5cb90e77198d3ddbcc25d388afb5
We *do* keep the code which ignores the presence of the file during
import, as an aid to future compatibility.

We can't do this by default for quite a while until support
for reading/ignoring the file has been out in the wild for e.g.
at least a month or two.