### PR TITLE
 container: Hard require `ostree.bootable` key

### DIFF
--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -309,6 +309,11 @@ pub(crate) fn parse_manifest_layout<'a>(
     Vec<&'a Descriptor>,
 )> {
     let config_labels = config.config().as_ref().and_then(|c| c.labels().as_ref());
+    let bootable_key = *ostree::METADATA_KEY_BOOTABLE;
+    let bootable = config_labels.map_or(false, |l| l.contains_key(bootable_key));
+    if !bootable {
+        anyhow::bail!("Target image does not have {bootable_key} label");
+    }
 
     let first_layer = manifest
         .layers()

--- a/lib/src/fixture.rs
+++ b/lib/src/fixture.rs
@@ -483,6 +483,7 @@ impl Fixture {
         );
         metadata.insert("ostree.container-cmd", &vec!["/usr/bin/bash"]);
         metadata.insert("version", &"42.0");
+        metadata.insert(*ostree::METADATA_KEY_BOOTABLE, &true);
         let metadata = metadata.to_variant();
         let commit = self.srcrepo.write_commit_with_time(
             None,

--- a/lib/src/fixture.rs
+++ b/lib/src/fixture.rs
@@ -539,6 +539,7 @@ impl Fixture {
         // Load our base commit
         let rev = &self.srcrepo().require_rev(self.testref())?;
         let (commit, _) = self.srcrepo.load_commit(rev)?;
+        let metadata = commit.child_value(0);
         let root = ostree::MutableTree::from_commit(self.srcrepo(), rev)?;
         // Bump the commit timestamp by one day
         let ts = chrono::Utc.timestamp(ostree::commit_get_timestamp(&commit) as i64, 0);
@@ -568,7 +569,15 @@ impl Fixture {
         let root = root.downcast_ref::<ostree::RepoFile>().unwrap();
         let commit = self
             .srcrepo
-            .write_commit_with_time(Some(rev), None, None, None, root, new_ts, cancellable)
+            .write_commit_with_time(
+                Some(rev),
+                None,
+                None,
+                Some(&metadata),
+                root,
+                new_ts,
+                cancellable,
+            )
             .context("Writing commit")?;
         self.srcrepo
             .transaction_set_ref(None, self.testref(), Some(commit.as_str()));

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -24,6 +24,7 @@ use ostree_ext::fixture::{FileDef, Fixture, CONTENTS_CHECKSUM_V0, CONTENTS_V0_LE
 const EXAMPLE_TAR_LAYER: &[u8] = include_bytes!("fixtures/hlinks.tar.gz");
 const TEST_REGISTRY_DEFAULT: &str = "localhost:5000";
 
+#[track_caller]
 fn assert_err_contains<T>(r: Result<T>, s: impl AsRef<str>) {
     let s = s.as_ref();
     let msg = format!("{:#}", r.err().expect("Expecting an error"));


### PR DESCRIPTION
tests: Propagate metadata from prior commit

We want in particular things like `ostree.bootable`.

---

tests: Use `#[track_caller]`

This way panics are properly attributed to the real source.

---

tests/fixture: Inject `ostree.bootable` by default

Since that's our intended use case for now.

---

container: Hard require `ostree.bootable` key

We want to give a clear and useful error when someone tries
to pull a non-ostree-based container image.

---

