### PR TITLE
container/store: Process whiteouts

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -43,6 +43,10 @@ pub mod chunking;
 pub(crate) mod commit;
 pub mod objectsource;
 pub(crate) mod objgv;
+#[cfg(feature = "internal-testing-api")]
+pub mod ostree_manual;
+#[cfg(not(feature = "internal-testing-api"))]
+mod ostree_manual;
 
 /// Prelude, intended for glob import.
 pub mod prelude {

--- a/lib/src/ostree_manual.rs
+++ b/lib/src/ostree_manual.rs
@@ -1,0 +1,35 @@
+//! Manual workarounds for ostree bugs
+
+use std::io::Read;
+use std::ptr;
+
+use ostree;
+use ostree::prelude::{Cast, InputStreamExtManual};
+use ostree::{gio, glib};
+
+#[allow(unsafe_code)]
+
+/// Equivalent of `g_file_read()` for ostree::RepoFile to work around an ostree bug.
+pub fn repo_file_read(f: &ostree::RepoFile) -> Result<gio::InputStream, glib::Error> {
+    use glib::translate::*;
+    let stream = unsafe {
+        let f = f.upcast_ref::<gio::File>();
+        let mut error = ptr::null_mut();
+        let stream = gio::ffi::g_file_read(f.to_glib_none().0, ptr::null_mut(), &mut error);
+        if !error.is_null() {
+            return Err(from_glib_full(error));
+        }
+        let stream = stream as *mut gio::ffi::GInputStream;
+        from_glib_full(stream)
+    };
+
+    Ok(stream)
+}
+
+/// Read a repo file to a string.
+pub fn repo_file_read_to_string(f: &ostree::RepoFile) -> anyhow::Result<String> {
+    let mut r = String::new();
+    let mut s = repo_file_read(f)?.into_read();
+    s.read_to_string(&mut r)?;
+    Ok(r)
+}

--- a/lib/src/ostree_manual.rs
+++ b/lib/src/ostree_manual.rs
@@ -7,9 +7,8 @@ use ostree;
 use ostree::prelude::{Cast, InputStreamExtManual};
 use ostree::{gio, glib};
 
+/// Equivalent of `g_file_read()` for ostree::RepoFile to work around https://github.com/ostreedev/ostree/issues/2703
 #[allow(unsafe_code)]
-
-/// Equivalent of `g_file_read()` for ostree::RepoFile to work around an ostree bug.
 pub fn repo_file_read(f: &ostree::RepoFile) -> Result<gio::InputStream, glib::Error> {
     use glib::translate::*;
     let stream = unsafe {
@@ -19,8 +18,8 @@ pub fn repo_file_read(f: &ostree::RepoFile) -> Result<gio::InputStream, glib::Er
         if !error.is_null() {
             return Err(from_glib_full(error));
         }
-        let stream = stream as *mut gio::ffi::GInputStream;
-        from_glib_full(stream)
+        // Upcast to GInputStream here
+        from_glib_full(stream as *mut gio::ffi::GInputStream)
     };
 
     Ok(stream)

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -9,7 +9,7 @@ use ostree_ext::container::{
     Config, ExportOpts, ImageReference, OstreeImageReference, SignatureSource, Transport,
 };
 use ostree_ext::ocidir;
-use ostree_ext::prelude::FileExt;
+use ostree_ext::prelude::{Cast, FileExt};
 use ostree_ext::tar::TarImportOptions;
 use ostree_ext::{gio, glib};
 use sh_inline::bash_in;
@@ -900,6 +900,7 @@ async fn test_container_import_export_v1() {
 /// But layers work via the container::write module.
 #[tokio::test]
 async fn test_container_write_derive() -> Result<()> {
+    let cancellable = gio::NONE_CANCELLABLE;
     let fixture = Fixture::new_v1()?;
     let base_oci_path = &fixture.path.join("exampleos.oci");
     let _digest = ostree_ext::container::encapsulate(
@@ -925,7 +926,11 @@ async fn test_container_write_derive() -> Result<()> {
     oci_clone(base_oci_path, derived_path).await?;
     let temproot = &fixture.path.join("temproot");
     std::fs::create_dir_all(&temproot.join("usr/bin"))?;
-    std::fs::write(temproot.join("usr/bin/newderivedfile"), "newderivedfile v0")?;
+    let newderivedfile_contents = "newderivedfile v0";
+    std::fs::write(
+        temproot.join("usr/bin/newderivedfile"),
+        newderivedfile_contents,
+    )?;
     std::fs::write(
         temproot.join("usr/bin/newderivedfile3"),
         "newderivedfile3 v0",
@@ -994,11 +999,18 @@ async fn test_container_write_derive() -> Result<()> {
     assert_eq!(config.os(), &oci_spec::image::Os::Linux);
 
     // Parse the commit and verify we pulled the derived content.
-    bash_in!(
-        &fixture.dir,
-        "ostree --repo=dest/repo ls ${r} /usr/bin/newderivedfile >/dev/null",
-        r = import.merge_commit.as_str()
-    )?;
+    let root = fixture
+        .destrepo()
+        .read_commit(&import.merge_commit, cancellable)?
+        .0;
+    let root = root.downcast_ref::<ostree::RepoFile>().unwrap();
+    {
+        let derived = root.resolve_relative_path("usr/bin/newderivedfile");
+        let derived = derived.downcast_ref::<ostree::RepoFile>().unwrap();
+        let found_newderived_contents =
+            ostree_ext::ostree_manual::repo_file_read_to_string(derived)?;
+        assert_eq!(found_newderived_contents, newderivedfile_contents);
+    }
 
     // Import again, but there should be no changes.
     let mut imp =


### PR DESCRIPTION
A long time ago, in a galaxy far far away, a few of us in the
ostree space did some initial work on Docker-related things; specifically
support for whiteouts landed in
https://github.com/ostreedev/ostree/commit/baaf7450da8a3870e8a42f0cdd4e0ea0ed5018d6

I wish at that time we'd realized how we could more natively
support fetching containers; but, it never occurred to me to fork
off skopeo to do all the heavy lifting for the *fetch* side, which
would have been a lot of work to reimplement particularly in C.
Oh well, better late than never!

Anyways, that whiteout processing was only designed to happen at
checkout time - i.e. when materializing the final filesystem tree.  I
think this was actually a misdesign and we should add
`ostree_mutable_tree_write_with_whiteouts` so that the whiteouts
are processed in-memory.

However for now, there's a relatively low cost to temporarily
materializing the merged tree via hardlinks and handle whiteouts
via the existing code, so let's do that.

Closes: https://github.com/ostreedev/ostree-rs-ext/issues/273

---

