### PR TITLE
lib: Release 0.8.4

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
-version = "0.8.3"
+version = "0.8.4"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
This adds a notable new feature in correctly handling Docker/OCI
whiteouts (file deletions) as well as accepting (but not writing)
refs in the tar stream.