### PR TITLE
bootabletree: Add an API to find kernel in fs checkout too

### DIFF
--- a/lib/src/bootabletree.rs
+++ b/lib/src/bootabletree.rs
@@ -1,12 +1,20 @@
 //! Helper functions for bootable OSTrees.
 
+use std::path::Path;
+
 use anyhow::Result;
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
+use cap_std::fs::Dir;
+use cap_std_ext::cap_std;
 use ostree::gio;
 use ostree::prelude::*;
 
-const MODULES: &str = "/usr/lib/modules";
+const MODULES: &str = "usr/lib/modules";
+const VMLINUZ: &str = "vmlinuz";
 
 /// Find the kernel modules directory in a bootable OSTree commit.
+/// The target directory will have a `vmlinuz` file representing the kernel binary.
 pub fn find_kernel_dir(
     root: &gio::File,
     cancellable: Option<&gio::Cancellable>,
@@ -20,10 +28,97 @@ pub fn find_kernel_dir(
     let mut r = None;
     for child in e.clone() {
         let child = &child?;
+        if child.file_type() != gio::FileType::Directory {
+            continue;
+        }
         let childpath = e.child(child);
-        if child.file_type() == gio::FileType::Directory && r.replace(childpath).is_some() {
+        let vmlinuz = childpath.child(VMLINUZ);
+        if !vmlinuz.query_exists(cancellable) {
+            continue;
+        }
+        if r.replace(childpath).is_some() {
             anyhow::bail!("Found multiple subdirectories in {}", MODULES);
         }
     }
     Ok(r)
+}
+
+fn read_dir_optional(
+    d: &Dir,
+    p: impl AsRef<Path>,
+) -> std::io::Result<Option<cap_std::fs::ReadDir>> {
+    match d.read_dir(p.as_ref()) {
+        Ok(r) => Ok(Some(r)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// Find the kernel modules directory in checked out directory tree.
+/// The target directory will have a `vmlinuz` file representing the kernel binary.
+pub fn find_kernel_dir_fs(root: &Dir) -> Result<Option<Utf8PathBuf>> {
+    let mut r = None;
+    let entries = if let Some(entries) = read_dir_optional(root, MODULES)? {
+        entries
+    } else {
+        return Ok(None);
+    };
+    for child in entries {
+        let child = &child?;
+        if !child.file_type()?.is_dir() {
+            continue;
+        }
+        let name = child.file_name();
+        let name = if let Some(n) = name.to_str() {
+            n
+        } else {
+            continue;
+        };
+        let mut pbuf = Utf8Path::new(MODULES).to_owned();
+        pbuf.push(name);
+        pbuf.push(VMLINUZ);
+        if !root.try_exists(&pbuf)? {
+            continue;
+        }
+        pbuf.pop();
+        if r.replace(pbuf).is_some() {
+            anyhow::bail!("Found multiple subdirectories in {}", MODULES);
+        }
+    }
+    Ok(r)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use cap_tempfile::cap_std;
+
+    #[test]
+    fn test_find_kernel_dir_fs() -> Result<()> {
+        let td = cap_tempfile::tempdir(cap_std::ambient_authority())?;
+
+        // Verify the empty case
+        assert!(find_kernel_dir_fs(&td).unwrap().is_none());
+        let moddir = Utf8Path::new("usr/lib/modules");
+        td.create_dir_all(moddir)?;
+        assert!(find_kernel_dir_fs(&td).unwrap().is_none());
+
+        let kpath = moddir.join("5.12.8-32.aarch64");
+        td.create_dir_all(&kpath)?;
+        td.write(kpath.join("vmlinuz"), "some kernel")?;
+        let kpath2 = moddir.join("5.13.7-44.aarch64");
+        td.create_dir_all(&kpath2)?;
+        td.write(kpath2.join("foo.ko"), "some kmod")?;
+
+        assert_eq!(
+            find_kernel_dir_fs(&td)
+                .unwrap()
+                .unwrap()
+                .file_name()
+                .unwrap(),
+            kpath.file_name().unwrap()
+        );
+
+        Ok(())
+    }
 }

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -1021,6 +1021,14 @@ async fn test_container_write_derive() -> Result<()> {
             ostree_ext::ostree_manual::repo_file_read_to_string(derived)?;
         assert_eq!(found_newderived_contents, newderivedfile_contents);
 
+        let kver = ostree_ext::bootabletree::find_kernel_dir(root.upcast_ref(), cancellable)
+            .unwrap()
+            .unwrap()
+            .basename()
+            .unwrap();
+        let kver = Utf8Path::from_path(&kver).unwrap();
+        assert_eq!(kver, newkdir.file_name().unwrap());
+
         let old_kernel_dir = root.resolve_relative_path(format!("usr/lib/modules/{oldkernel}"));
         assert!(!old_kernel_dir.query_exists(cancellable));
     }


### PR DESCRIPTION
See https://github.com/coreos/rpm-ostree/pull/3966#discussion_r955281628

I want to switch over rpm-ostree to use this API instead of
reimplementing it.

This also adds test coverage for the existing GFile based API.