### PR TITLE
deploy: Add a `--no-imgref` option

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -802,6 +802,7 @@ where
                         kargs: kargs.as_deref(),
                         target_imgref: target_imgref.as_ref(),
                         proxy_cfg: Some(proxyopts.into()),
+                        ..Default::default()
                     };
                     let state = crate::container::deploy::deploy(
                         sysroot,

--- a/lib/src/container/deploy.rs
+++ b/lib/src/container/deploy.rs
@@ -27,6 +27,12 @@ pub struct DeployOpts<'a> {
 
     /// Configuration for fetching containers.
     pub proxy_cfg: Option<super::store::ImageProxyConfig>,
+
+    /// If true, then no image reference will be written; but there will be refs
+    /// for the fetched layers.  This ensures that if the machine is later updated
+    /// to a different container image, the fetch process will reuse shared layers, but
+    /// it will not be necessary to remove the previous image.
+    pub no_imgref: bool,
 }
 
 /// Write a container image to an OSTree deployment.
@@ -47,6 +53,9 @@ pub async fn deploy(
             .await?;
     if let Some(target) = options.target_imgref {
         imp.set_target(target);
+    }
+    if options.no_imgref {
+        imp.set_no_imgref();
     }
     let state = match imp.prepare().await? {
         PrepareResult::AlreadyPresent(r) => r,


### PR DESCRIPTION
In https://github.com/coreos/coreos-assembler/pull/2523 we
taught coreos-assembler how to generate disk images with a
"pre-pulled" container image.  This means that the *first* OS update
will use shared layers.

However...right now running e.g. `rpm-ostree rebase quay.io/newimage`
won't necessarily prune the previous image.  (This may be considered
a bug)

But in practice, particularly for RHEL CoreOS we may not want to have
a default image reference - we don't (necessarily) want typing
`rpm-ostree upgrade` to do something.

With this, we can effectively pre-pull just the layers but not
the final image.