### PR TITLE
container/deploy: Add support for retaining

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -290,6 +290,10 @@ enum ContainerImageOpts {
         /// Write the deployed checksum to this file
         #[structopt(long)]
         write_commitid_to: Option<Utf8PathBuf>,
+
+        #[structopt(long)]
+        /// Do not remove any other deployments
+        retain: bool,
     },
 }
 
@@ -782,6 +786,7 @@ where
                     karg,
                     proxyopts,
                     write_commitid_to,
+                    retain,
                 } => {
                     let sysroot = &ostree::Sysroot::new(Some(&gio::File::for_path(&sysroot)));
                     sysroot.load(gio::NONE_CANCELLABLE)?;
@@ -795,6 +800,7 @@ where
                         kargs: kargs.as_deref(),
                         target_imgref: target_imgref.as_ref(),
                         proxy_cfg: Some(proxyopts.into()),
+                        retain,
                         ..Default::default()
                     };
                     let state = crate::container::deploy::deploy(

--- a/lib/src/container/deploy.rs
+++ b/lib/src/container/deploy.rs
@@ -33,6 +33,9 @@ pub struct DeployOpts<'a> {
     /// to a different container image, the fetch process will reuse shared layers, but
     /// it will not be necessary to remove the previous image.
     pub no_imgref: bool,
+
+    /// If true, do not remove any other deployments
+    pub retain: bool,
 }
 
 /// Write a container image to an OSTree deployment.
@@ -73,7 +76,11 @@ pub async fn deploy(
         options.kargs.unwrap_or_default(),
         cancellable,
     )?;
-    let flags = ostree::SysrootSimpleWriteDeploymentFlags::NONE;
+    let flags = if options.retain {
+        ostree::SysrootSimpleWriteDeploymentFlags::RETAIN
+    } else {
+        ostree::SysrootSimpleWriteDeploymentFlags::NONE
+    };
     sysroot.simple_write_deployment(Some(stateroot), deployment, None, flags, cancellable)?;
     sysroot.cleanup(cancellable)?;
 


### PR DESCRIPTION
This is needed for https://github.com/coreos/rpm-ostree/issues/4018 where we want to run the new ostree code from a container image.

Without this, ostree will think we're not booted into a deployment, and when we write a new one it will just happily delete the running root filesystem...