### PR TITLE
Release 0.8.6

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
-version = "0.8.5"
+version = "0.8.6"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Mainly to get the deploy changes out so we can get a firstboot path in OCP that doesn't involve double reboot.