### PR TITLE
container: Support writing tags to `oci:` directories

### DIFF
--- a/lib/src/container/update_detachedmeta.rs
+++ b/lib/src/container/update_detachedmeta.rs
@@ -122,7 +122,7 @@ pub async fn update_detached_metadata(
         manifest.set_config(new_config_descriptor);
         // This entirely replaces the single entry in the OCI directory, which skopeo will find by default.
         tempsrc
-            .write_manifest(manifest, platform)
+            .replace_with_single_manifest(manifest, platform)
             .context("Writing manifest")?;
         Ok(())
     })

--- a/lib/src/integrationtest.rs
+++ b/lib/src/integrationtest.rs
@@ -28,7 +28,11 @@ pub(crate) fn detectenv() -> &'static str {
 /// Using `src` as a base, take append `dir` into OCI image.
 /// Should only be enabled for testing.
 #[context("Generating derived oci")]
-pub fn generate_derived_oci(src: impl AsRef<Utf8Path>, dir: impl AsRef<Utf8Path>) -> Result<()> {
+pub fn generate_derived_oci(
+    src: impl AsRef<Utf8Path>,
+    dir: impl AsRef<Utf8Path>,
+    tag: Option<&str>,
+) -> Result<()> {
     let src = src.as_ref();
     let src = Dir::open_ambient_dir(src, cap_std::ambient_authority())?;
     let src = ocidir::OciDir::open(&src)?;
@@ -63,7 +67,11 @@ pub fn generate_derived_oci(src: impl AsRef<Utf8Path>, dir: impl AsRef<Utf8Path>
     let new_config_desc = src.write_config(config)?;
     manifest.set_config(new_config_desc);
 
-    src.write_manifest(manifest, oci_image::Platform::default())?;
+    if let Some(tag) = tag {
+        src.insert_manifest(manifest, Some(tag), oci_image::Platform::default())?;
+    } else {
+        src.replace_with_single_manifest(manifest, oci_image::Platform::default())?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
I want to teach coreos-assembler to maintain an oci directory with version tags for builds instead of using an ostree repository.

It now works to do e.g.:

```
$ ostree-ext-cli container encapsulate --repo=tmp/repo 36.20220920.dev.0 oci:tmp/builds:36.20220920.dev.0
$ ostree-ext-cli container encapsulate --repo=tmp/repo 36.20220920.dev.1 oci:tmp/builds:36.20220920.dev.1
```

But in an OCI/container native build flow, we'd write the OCI builds not as `.ociarchive` but in an oci directory `builds-oci` or so.

Closes: https://github.com/ostreedev/ostree-rs-ext/issues/154