### PR TITLE
 commit: Ignore files and directories not on the root mount

### DIFF
--- a/ci/container-build-integration.sh
+++ b/ci/container-build-integration.sh
@@ -13,8 +13,9 @@ sed -ie 's,ostree container commit,ostree-ext-cli container commit,' Dockerfile
 sed -ie 's,^\(FROM .*\),\1\nADD ostree-ext-cli /usr/bin,' Dockerfile
 git diff
 
-docker build -t localhost/fcos-tailscale .
-
-docker run --rm localhost/fcos-tailscale rpm -q tailscale
+for runtime in podman docker; do
+    $runtime build -t localhost/fcos-tailscale .
+    $runtime run --rm localhost/fcos-tailscale rpm -q tailscale
+done
 
 echo ok container image integration

--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -9,28 +9,37 @@ use camino::Utf8Path;
 use cap_std::fs::Dir;
 use cap_std_ext::cap_std;
 use cap_std_ext::dirext::CapStdExtDirExt;
+use cap_std_ext::rustix::fs::MetadataExt;
 use std::convert::TryInto;
 use std::path::Path;
+use std::path::PathBuf;
 use tokio::task;
 
 /// Directories for which we will always remove all content.
 const FORCE_CLEAN_PATHS: &[&str] = &["run", "tmp", "var/tmp", "var/cache"];
 
 /// Gather count of non-empty directories.  Empty directories are removed.
-fn process_dir_recurse(root: &Dir, path: &Utf8Path, error_count: &mut i32) -> Result<bool> {
+fn process_dir_recurse(
+    root: &Dir,
+    rootdev: u64,
+    path: &Utf8Path,
+    error_count: &mut i32,
+) -> Result<bool> {
     let context = || format!("Validating: {path}");
     let mut validated = true;
     for entry in root.read_dir(path).with_context(context)? {
         let entry = entry?;
+        let metadata = entry.metadata()?;
+        if metadata.dev() != rootdev {
+            continue;
+        }
         let name = entry.file_name();
         let name = Path::new(&name);
         let name: &Utf8Path = name.try_into()?;
         let path = &path.join(name);
 
-        let metadata = root.symlink_metadata(path)?;
-
         if metadata.is_dir() {
-            if !process_dir_recurse(root, path, error_count)? {
+            if !process_dir_recurse(root, rootdev, path, error_count)? {
                 validated = false;
             }
         } else {
@@ -47,24 +56,68 @@ fn process_dir_recurse(root: &Dir, path: &Utf8Path, error_count: &mut i32) -> Re
     Ok(validated)
 }
 
-fn clean_paths_in(root: &Dir) -> Result<()> {
-    for path in FORCE_CLEAN_PATHS {
-        if let Some(subdir) = root.open_dir_optional(path)? {
-            for entry in subdir.entries()? {
-                let entry = entry?;
-                subdir.remove_all_optional(entry.file_name())?;
-            }
+/// Recursively remove the target directory, but avoid traversing across mount points.
+fn remove_all_on_mount_recurse(root: &Dir, rootdev: u64, path: &Path) -> Result<bool> {
+    let mut skipped = false;
+    for entry in root.read_dir(path)? {
+        let entry = entry?;
+        let metadata = entry.metadata()?;
+        if metadata.dev() != rootdev {
+            skipped = true;
+            continue;
+        }
+        let name = entry.file_name();
+        let path = &path.join(name);
+
+        if metadata.is_dir() {
+            skipped |= remove_all_on_mount_recurse(root, rootdev, path.as_path())?;
+        } else {
+            root.remove_file(path)?;
+        }
+    }
+    if !skipped {
+        root.remove_dir(&path)?;
+    }
+    Ok(skipped)
+}
+
+fn clean_subdir(root: &Dir, rootdev: u64) -> Result<()> {
+    for entry in root.entries()? {
+        let entry = entry?;
+        let metadata = entry.metadata()?;
+        let dev = metadata.dev();
+        // Ignore other filesystem mounts, e.g. podman injects /run/.containerenv
+        if dev != rootdev {
+            continue;
+        }
+        let path = PathBuf::from(entry.file_name());
+        if metadata.is_dir() {
+            remove_all_on_mount_recurse(root, rootdev, &path)?;
+        } else {
+            root.remove_file(&path)?;
         }
     }
     Ok(())
 }
 
+fn clean_paths_in(root: &Dir, rootdev: u64) -> Result<()> {
+    for path in FORCE_CLEAN_PATHS {
+        let subdir = if let Some(subdir) = root.open_dir_optional(path)? {
+            subdir
+        } else {
+            continue;
+        };
+        clean_subdir(&subdir, rootdev).with_context(|| format!("Cleaning {path}"))?;
+    }
+    Ok(())
+}
+
 #[allow(clippy::collapsible_if)]
-fn process_var(root: &Dir, strict: bool) -> Result<()> {
+fn process_var(root: &Dir, rootdev: u64, strict: bool) -> Result<()> {
     let var = Utf8Path::new("var");
     let mut error_count = 0;
     if root.try_exists(var)? {
-        if !process_dir_recurse(root, var, &mut error_count)? && strict {
+        if !process_dir_recurse(root, rootdev, var, &mut error_count)? && strict {
             anyhow::bail!("Found content in {var}");
         }
     }
@@ -74,15 +127,17 @@ fn process_var(root: &Dir, strict: bool) -> Result<()> {
 /// Given a root filesystem, clean out empty directories and warn about
 /// files in /var.  /run, /tmp, and /var/tmp have their contents recursively cleaned.
 pub fn prepare_ostree_commit_in(root: &Dir) -> Result<()> {
-    clean_paths_in(root)?;
-    process_var(root, true)
+    let rootdev = root.dir_metadata()?.dev();
+    clean_paths_in(root, rootdev)?;
+    process_var(root, rootdev, true)
 }
 
 /// Like [`prepare_ostree_commit_in`] but only emits warnings about unsupported
 /// files in `/var` and will not error.
 pub fn prepare_ostree_commit_in_nonstrict(root: &Dir) -> Result<()> {
-    clean_paths_in(root)?;
-    process_var(root, false)
+    let rootdev = root.dir_metadata()?.dev();
+    clean_paths_in(root, rootdev)?;
+    process_var(root, rootdev, false)
 }
 
 /// Entrypoint to the commit procedures, initially we just


### PR DESCRIPTION
ci: Also check via podman

It turns out that podman adds default mounts in `/run` which
means there's a behavior difference here.

But we want to cross check with both on general principle.  I was
just using `docker` because I thought podman might not be installed
on the stock GH action runner, but it apparently is.

---

commit: Ignore files and directories not on the root mount

podman injects e.g. `/run/.containerenv` as a tmpfs mount.  We should
not attempt to remove this - it will be gone when podman goes to
write the tar stream itself.

Also in the general case, traversing and recursively removing
is potentially really dangerous if e.g. someone mounted an external
drive during a container build process at say `/var/srv`.  Hopefully
most of those cases would be read-only, but still.  Ultimately
the point is that we only want to remove files that will become
part of the serialized tar stream.

Pass the device ID of `/` down into our traversal and ignore
files/directories which don't match.

---

