### PR TITLE
Add compat feature and bump semver to 0.9

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,6 +41,21 @@ jobs:
         run: (cd cli && cargo check) && (cd lib && cargo check)
       - name: Run tests
         run: cargo test -- --nocapture --quiet
+  test-compat:
+    runs-on: ubuntu-latest
+    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install deps
+        run: ./ci/installdeps.sh
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v1
+        with:
+          key: "test-compat"
+      - name: Build
+        run: cargo test --no-run --features=compat
+      - name: Run tests
+        run: cargo test --features=compat -- --nocapture --quiet
   build:
     runs-on: ubuntu-latest
     container: quay.io/coreos-assembler/fcos-buildroot:testing-devel

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
-version = "0.8.9"
+version = "0.9.0"
 
 [dependencies]
 anyhow = "1.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -57,4 +57,5 @@ features = ["dox"]
 
 [features]
 dox = ["ostree/dox"]
+compat = []
 internal-testing-api = ["sh-inline", "indoc"]

--- a/lib/src/container/encapsulate.rs
+++ b/lib/src/container/encapsulate.rs
@@ -31,8 +31,11 @@ pub enum ExportLayout {
 
 impl Default for ExportLayout {
     fn default() -> Self {
-        // For now
-        Self::V0
+        if cfg!(feature = "compat") {
+            Self::V0
+        } else {
+            Self::V1
+        }
     }
 }
 
@@ -124,6 +127,10 @@ fn export_chunked(
 
     match opts.format {
         ExportLayout::V0 => {
+            if cfg!(not(feature = "compat")) {
+                let label = opts.format.label();
+                anyhow::bail!("This legacy format using the {label} label is no longer supported");
+            }
             // In V0, the component/content chunks come first.
             for (layer, name) in layers {
                 ociw.push_layer(manifest, imgcfg, layer, name.as_str());

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -371,6 +371,13 @@ pub(crate) fn parse_manifest_layout<'a>(
         // Now, we need to handle the split differently in chunked v1 vs v0
         match layout {
             ExportLayout::V0 => {
+                if cfg!(not(feature = "compat")) {
+                    let label = layout.label();
+                    anyhow::bail!(
+                        "This legacy format using the {label} label is no longer supported"
+                    );
+                }
+
                 for layer in manifest.layers() {
                     if layer == target_layer {
                         if after_target {

--- a/lib/src/fixture.rs
+++ b/lib/src/fixture.rs
@@ -395,7 +395,7 @@ impl Fixture {
             path,
             srcrepo,
             destrepo,
-            format_version: 0,
+            format_version: if cfg!(feature = "compat") { 0 } else { 1 },
             selinux: true,
         })
     }

--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -20,7 +20,11 @@ use std::ops::RangeInclusive;
 pub const BARE_SPLIT_XATTRS_MODE: &str = "bare-split-xattrs";
 
 /// The set of allowed format versions; ranges from zero to 1, inclusive.
+#[cfg(feature = "compat")]
 pub const FORMAT_VERSIONS: RangeInclusive<u32> = 0..=1;
+#[cfg(not(feature = "compat"))]
+/// The set of allowed format versions.
+pub const FORMAT_VERSIONS: RangeInclusive<u32> = 1..=1;
 
 // This is both special in the tar stream *and* it's in the ostree commit.
 const SYSROOT: &str = "sysroot";
@@ -567,10 +571,18 @@ fn impl_export<W: std::io::Write>(
 }
 
 /// Configuration for tar export.
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ExportOptions {
     /// Format version; must be in [`FORMAT_VERSIONS`].
     pub format_version: u32,
+}
+
+impl Default for ExportOptions {
+    fn default() -> Self {
+        Self {
+            format_version: if cfg!(feature = "compat") { 0 } else { 1 },
+        }
+    }
 }
 
 /// Export an ostree commit to an (uncompressed) tar archive stream.


### PR DESCRIPTION
Add a `compat` feature

This is the first step towards disabling our support for old
tar formats and the legacy container formats.

When the `compat` feature is off, everything defaults to v1
format, and we reject parsing the old v0 container images in
particular.

---

Bump semver to 0.9

Because we have an off-by-default `compat` feature.

---

