### PR TITLE
Release 0.8.7

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
-version = "0.8.6"
+version = "0.8.7"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
We need to get the `ostree container commit` fix out.