### PR TITLE
cargo: bump to clap v4

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.64.0"
 [dependencies]
 anyhow = "1.0"
 ostree-ext = { path = "../lib" }
-clap = "3.2"
+clap = "4.2"
 libc = "0.2.92"
 tokio = { version = "1", features = ["macros"] }
 log = "0.4.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,8 +17,8 @@ bitflags = "1"
 camino = "1.0.4"
 chrono = "0.4.19"
 olpc-cjson = "0.1.1"
-clap = { version= "3.2", features = ["derive"] }
-clap_mangen = { version = "0.1", optional = true }
+clap = { version= "4.2", features = ["derive"] }
+clap_mangen = { version = "0.2", optional = true }
 cap-std-ext = "2.0"
 cap-tempfile = "1.0"
 flate2 = { features = ["zlib"], default_features = false, version = "1.0.20" }

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -57,7 +57,7 @@ pub(crate) struct ExportOpts {
     repo: Utf8PathBuf,
 
     /// The format version.  Must be 1.
-    #[clap(long, hidden(true))]
+    #[clap(long, hide(true))]
     format_version: u32,
 
     /// The ostree ref or commit to export

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -139,7 +139,6 @@ pub(crate) enum ContainerOpts {
         compression_fast: bool,
     },
 
-    #[clap(alias = "commit")]
     /// Perform build-time checking and canonicalization.
     /// This is presently an optional command, but may become required in the future.
     Commit,

--- a/lib/src/docgen.rs
+++ b/lib/src/docgen.rs
@@ -36,7 +36,11 @@ fn generate_one(directory: &Utf8Path, cmd: Command) -> Result<()> {
 
     for subcmd in cmd.get_subcommands().filter(|c| !c.is_hide_set()) {
         let subname = format!("{}-{}", name, subcmd.get_name());
-        generate_one(directory, subcmd.clone().name(subname).version(version))?;
+        // SAFETY: Latest clap 4 requires names are &'static - this is
+        // not long-running production code, so we just leak the names here.
+        let subname = &*std::boxed::Box::leak(subname.into_boxed_str());
+        let subcmd = subcmd.clone().name(subname).alias(subname).version(version);
+        generate_one(directory, subcmd)?;
     }
     Ok(())
 }


### PR DESCRIPTION
RFC: clap v4 comes with several additional deprecations, which I haven't yet looked at. We can either do it here, or leave it for later.