### PR TITLE
container: Loosen container detection to work with `docker buildx`

### DIFF
--- a/ci/container-build-integration.sh
+++ b/ci/container-build-integration.sh
@@ -6,16 +6,27 @@ image=quay.io/coreos-assembler/fcos:stable
 example=coreos-layering-examples/tailscale
 set -x
 
-mv ostree-ext-cli ${example}
-cd ${example}
 chmod a+x ostree-ext-cli
+workdir=${PWD}
+cd ${example}
+cp ${workdir}/ostree-ext-cli .
 sed -ie 's,ostree container commit,ostree-ext-cli container commit,' Dockerfile
-sed -ie 's,^\(FROM .*\),\1\nADD ostree-ext-cli /usr/bin,' Dockerfile
+sed -ie 's,^\(FROM .*\),\1\nADD ostree-ext-cli /usr/bin/,' Dockerfile
 git diff
 
 for runtime in podman docker; do
     $runtime build -t localhost/fcos-tailscale .
     $runtime run --rm localhost/fcos-tailscale rpm -q tailscale
 done
+
+cd $(mktemp -d)
+cp ${workdir}/ostree-ext-cli .
+cat > Dockerfile << EOF
+FROM $image
+ADD ostree-ext-cli /usr/bin/
+RUN set -x; test \$(ostree-ext-cli internal-only-for-testing detect-env) = ostree-container
+EOF
+# Also verify docker buildx, which apparently doesn't have /.dockerenv
+docker buildx build -t localhost/fcos-tailscale .
 
 echo ok container image integration

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -661,8 +661,7 @@ fn ima_sign(cmdopts: &ImaSignOpts) -> Result<()> {
 async fn testing(opts: &TestingOpts) -> Result<()> {
     match opts {
         TestingOpts::DetectEnv => {
-            let s = crate::integrationtest::detectenv();
-            println!("{}", s);
+            println!("{}", crate::integrationtest::detectenv()?);
             Ok(())
         }
         TestingOpts::CreateFixture => crate::integrationtest::create_fixture().await,


### PR DESCRIPTION
Apparently, `docker buildx build` creates containers without `/.dockerenv`.  I debated forcing on a `container=oci` environment variable for our containers, but upon some reflection I think it's about equally as clean to loosen our container detection logic.

The presence of a bare-split-xattrs ostree repo is a powerful signal. Let's use that as the signal, unless overridden by strong contrary evidence:

- We're running under systemd
- We are apparently on a booted ostree systemd

Closes: https://github.com/ostreedev/ostree-rs-ext/issues/380