### PR TITLE
Fix deploy error

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -812,9 +812,10 @@ where
                         Some(options),
                     )
                     .await?;
+                    let wrote_imgref = target_imgref.as_ref().unwrap_or(&imgref);
                     if let Some(msg) = ostree_container::store::image_filtered_content_warning(
                         repo,
-                        &imgref.imgref,
+                        &wrote_imgref.imgref,
                     )? {
                         eprintln!("{msg}")
                     }

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -426,6 +426,7 @@ impl ImageImporter {
     }
 
     /// Determine if there is a new manifest, and if so return its digest.
+    #[context("Preparing import")]
     pub async fn prepare(&mut self) -> Result<PrepareResult> {
         self.prepare_internal(false).await
     }
@@ -649,6 +650,7 @@ impl ImageImporter {
     }
 
     /// Import a layered container image
+    #[context("Importing")]
     pub async fn import(
         mut self,
         mut import: Box<PreparedImport>,


### PR DESCRIPTION
lib/container: Add context to prepare/import

I was debugging an error and was trying to figure out which
of these it was coming from (the answer was neither though).

---

cli: Fix error when using deploy --target-imgref

I was trying to use https://github.com/coreos/coreos-assembler/pull/2523
to test something and discovered that
https://github.com/coreos/coreos-assembler/pull/2523
regressed this.  We need to use the target imgref if provided.

---

