### PR TITLE
Automatically log some container metadata to systemd journal (if avail)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: quay.io/coreos-assembler/fcos:testing-devel
-      options: "--privileged -v /:/run/host"
+      options: "--privileged --pid=host -v /run/systemd/journal:/run/systemd/journal -v /:/run/host"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/ci/priv-integration.sh
+++ b/ci/priv-integration.sh
@@ -40,4 +40,8 @@ for img in "${image}" "${old_image}"; do
     fi
 done
 
+# Verify we have systemd journal messages
+nsenter -m -t 1 journalctl _COMM=ostree-ext-cli > logs.txt
+grep 'layers stored: ' logs.txt
+
 echo ok privileged integration

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -27,6 +27,7 @@ hex = "0.4.3"
 indicatif = "0.17.0"
 once_cell = "1.9"
 libc = "0.2.92"
+libsystemd = "0.5.0"
 oci-spec = "0.5.4"
 openssl = "0.10.33"
 ostree = { features = ["v2021_5", "cap-std-apis"], version = "0.15.0" }

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -449,18 +449,8 @@ async fn handle_layer_progress_print(
 }
 
 fn print_layer_status(prep: &PreparedImport) {
-    let (stored, to_fetch, to_fetch_size) =
-        prep.all_layers()
-            .fold((0u32, 0u32, 0u64), |(stored, to_fetch, sz), v| {
-                if v.commit.is_some() {
-                    (stored + 1, to_fetch, sz)
-                } else {
-                    (stored, to_fetch + 1, sz + v.size())
-                }
-            });
-    if to_fetch > 0 {
-        let size = crate::glib::format_size(to_fetch_size);
-        println!("layers stored: {stored} needed: {to_fetch} ({size})");
+    if let Some(status) = prep.format_layer_status() {
+        println!("{status}");
     }
 }
 

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -6,6 +6,7 @@
 //! base.  See [`encapsulate`][`super::encapsulate()`] for more information on encaspulation of images.
 
 use super::*;
+use crate::logging::system_repo_journal_print;
 use crate::refescape;
 use anyhow::{anyhow, Context};
 use containers_image_proxy::{ImageProxy, OpenedImage};
@@ -226,6 +227,23 @@ impl PreparedImport {
             .transpose()
         })
     }
+
+    /// Common helper to format a string for the status
+    pub(crate) fn format_layer_status(&self) -> Option<String> {
+        let (stored, to_fetch, to_fetch_size) =
+            self.all_layers()
+                .fold((0u32, 0u32, 0u64), |(stored, to_fetch, sz), v| {
+                    if v.commit.is_some() {
+                        (stored + 1, to_fetch, sz)
+                    } else {
+                        (stored, to_fetch + 1, sz + v.size())
+                    }
+                });
+        (to_fetch > 0).then(|| {
+            let size = crate::glib::format_size(to_fetch_size);
+            format!("layers stored: {stored} needed: {to_fetch} ({size})")
+        })
+    }
 }
 
 // Given a manifest, compute its ostree ref name and cached ostree commit
@@ -399,6 +417,13 @@ impl ImageImporter {
         // Apply our defaults to the proxy config
         merge_default_container_proxy_opts(&mut config)?;
         let proxy = ImageProxy::new_with_config(config).await?;
+
+        system_repo_journal_print(
+            repo,
+            libsystemd::logging::Priority::Info,
+            &format!("Fetching {}", imgref),
+        );
+
         let proxy_img = proxy.open_image(&imgref.imgref.to_string()).await?;
         let repo = repo.clone();
         Ok(ImageImporter {
@@ -655,6 +680,9 @@ impl ImageImporter {
         mut self,
         mut import: Box<PreparedImport>,
     ) -> Result<Box<LayeredImageState>> {
+        if let Some(status) = import.format_layer_status() {
+            system_repo_journal_print(&self.repo, libsystemd::logging::Priority::Info, &status);
+        }
         // First download all layers for the base image (if necessary) - we need the SELinux policy
         // there to label all following layers.
         self.unencapsulate_base(&mut import, true).await?;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -35,6 +35,7 @@ pub mod container_utils;
 pub mod diff;
 pub mod ima;
 pub mod keyfileext;
+pub(crate) mod logging;
 pub mod refescape;
 pub mod tar;
 pub mod tokio_util;

--- a/lib/src/logging.rs
+++ b/lib/src/logging.rs
@@ -1,0 +1,37 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Set to true if we failed to write to the journal once
+static EMITTED_JOURNAL_ERROR: AtomicBool = AtomicBool::new(false);
+
+/// Wrapper for systemd structured logging which only emits a message
+/// if we're targeting the system repository, and it's booted.
+pub(crate) fn system_repo_journal_send<K, V>(
+    repo: &ostree::Repo,
+    priority: libsystemd::logging::Priority,
+    msg: &str,
+    vars: impl Iterator<Item = (K, V)>,
+) where
+    K: AsRef<str>,
+    V: AsRef<str>,
+{
+    if !repo.is_system() {
+        return;
+    }
+    if let Err(e) = libsystemd::logging::journal_send(priority, msg, vars) {
+        if !EMITTED_JOURNAL_ERROR.swap(true, Ordering::SeqCst) {
+            eprintln!("failed to write to journal: {e}");
+        }
+    }
+}
+
+/// Wrapper for systemd structured logging which only emits a message
+/// if we're targeting the system repository, and it's booted.
+pub(crate) fn system_repo_journal_print(
+    repo: &ostree::Repo,
+    priority: libsystemd::logging::Priority,
+    msg: &str,
+) {
+    let vars: HashMap<&str, &str> = HashMap::new();
+    system_repo_journal_send(repo, priority, msg, vars.into_iter())
+}


### PR DESCRIPTION
I was logged into one of my OpenShift machines live and watching `journalctl -b -u rpm-ostreed -f` during an upgrade, and was surprised not to see any useful output.

This is because of course rpm-ostreed logs everything to the client, in this case the MCD.

I think we should also duplicate these messages directly in the journal.  libostree does something similar when fetching via HTTP.