### PR TITLE
container: Force on anonymous fetches if no config file

### DIFF
--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -219,6 +219,12 @@ pub fn merge_default_container_proxy_opts(
 ) -> Result<()> {
     if !config.auth_anonymous && config.authfile.is_none() {
         config.authfile = crate::globals::get_global_authfile_path()?;
+        // If there's no authfile, then force on anonymous pulls to ensure
+        // that the container stack doesn't try to find it in the standard
+        // container paths.
+        if config.authfile.is_none() {
+            config.auth_anonymous = true;
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
We've seen a weird error out of the container stack when we're not authorized to fetch an image, *and* no pull secret is set up.

e.g.  https://github.com/coreos/rpm-ostree/issues/4107

```
error: remote error: getting username and password: 1 error occurred:
	* reading JSON file "/run/containers/62011/auth.json": open /run/containers/62011/auth.json: permission denied
```

We don't want the containers/image stack trying to read the "standard" config paths at the moment for a few reasons; one is that the standard paths conflate "root" and "the system".  We want to support separate pull secrets.  But, it should also work to symlink the authfile.