### PR TITLE
logging: Don't write to journal if not running systemd

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: quay.io/fedora/fedora-coreos:testing-devel
-      options: "--privileged --pid=host -v /run/systemd/journal:/run/systemd/journal -v /:/run/host"
+      options: "--privileged --pid=host -v /run/systemd:/run/systemd -v /:/run/host"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/lib/src/logging.rs
+++ b/lib/src/logging.rs
@@ -15,6 +15,9 @@ pub(crate) fn system_repo_journal_send<K, V>(
     K: AsRef<str>,
     V: AsRef<str>,
 {
+    if !libsystemd::daemon::booted() {
+        return;
+    }
     if !repo.is_system() {
         return;
     }


### PR DESCRIPTION
I noticed an error message when we're doing the deployment in supermin in coreos-assembler.