### PR TITLE
Two minor patches

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
 readme = "README.md"
+publish = false
 
 [dependencies]
 anyhow = "1.0"

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -46,8 +46,6 @@ pub mod objectsource;
 pub(crate) mod objgv;
 #[cfg(feature = "internal-testing-api")]
 pub mod ostree_manual;
-#[cfg(not(feature = "internal-testing-api"))]
-mod ostree_manual;
 
 /// Prelude, intended for glob import.
 pub mod prelude {


### PR DESCRIPTION
cli: Don't publish

We aren't productizing this CLI entrypoint.

---

Don't expose `ostree_manual` API at all in non-test mode

This avoids dead code warnings for external crate users.

---

