### PR TITLE
Initial support for generating manpages

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,6 +41,8 @@ jobs:
         run: (cd cli && cargo check) && (cd lib && cargo check)
       - name: Run tests
         run: cargo test -- --nocapture --quiet
+      - name: Manpage generation
+        run: mkdir -p target/man && cargo run --features=docgen -- man --directory target/man
   test-compat:
     runs-on: ubuntu-latest
     container: quay.io/coreos-assembler/fcos-buildroot:testing-devel

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,6 +17,7 @@ camino = "1.0.4"
 chrono = "0.4.19"
 cjson = "0.1.1"
 clap = { version= "3.2", features = ["derive"] }
+clap_mangen = { version = "0.1", optional = true }
 cap-std-ext = "0.26"
 cap-tempfile = "0.25"
 flate2 = { features = ["zlib"], default_features = false, version = "1.0.20" }
@@ -56,6 +57,7 @@ ostree-ext = { path = ".", features = ["internal-testing-api"] }
 features = ["dox"]
 
 [features]
+docgen = ["clap_mangen"]
 dox = ["ostree/dox"]
 compat = []
 internal-testing-api = ["sh-inline", "indoc"]

--- a/lib/src/docgen.rs
+++ b/lib/src/docgen.rs
@@ -1,0 +1,42 @@
+// Copyright 2022 Red Hat, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use anyhow::{Context, Result};
+use camino::Utf8Path;
+use clap::{Command, CommandFactory};
+use std::fs::OpenOptions;
+use std::io::Write;
+
+pub fn generate_manpages(directory: &Utf8Path) -> Result<()> {
+    generate_one(directory, crate::cli::Opt::command())
+}
+
+fn generate_one(directory: &Utf8Path, cmd: Command) -> Result<()> {
+    let version = env!("CARGO_PKG_VERSION");
+    let name = cmd.get_name();
+    let path = directory.join(format!("{name}.8"));
+    println!("Generating {path}...");
+
+    let mut out = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(&path)
+        .with_context(|| format!("opening {path}"))
+        .map(std::io::BufWriter::new)?;
+    clap_mangen::Man::new(cmd.clone())
+        .title("ostree-ext")
+        .section("8")
+        .source(format!("ostree-ext {version}"))
+        .render(&mut out)
+        .with_context(|| format!("rendering {name}.8"))?;
+    out.flush().context("flushing man page")?;
+    drop(out);
+
+    for subcmd in cmd.get_subcommands().filter(|c| !c.is_hide_set()) {
+        let subname = format!("{}-{}", name, subcmd.get_name());
+        generate_one(directory, subcmd.clone().name(subname).version(version))?;
+    }
+    Ok(())
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -47,6 +47,9 @@ pub(crate) mod objgv;
 #[cfg(feature = "internal-testing-api")]
 pub mod ostree_manual;
 
+#[cfg(feature = "docgen")]
+mod docgen;
+
 /// Prelude, intended for glob import.
 pub mod prelude {
     #[doc(hidden)]


### PR DESCRIPTION
It's about time we had online (and shipped in packages) docs for our tools.

Some code inspired/taken from https://github.com/coreos/coreos-installer/blob/main/src/cmdline/doc.rs