### PR TITLE
container: Add an API to query information from a commit object

### DIFF
--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -771,7 +771,6 @@ impl ImageImporter {
 
         // Destructure to transfer ownership to thread
         let repo = self.repo;
-        let imgref = self.target_imgref.unwrap_or(self.imgref);
         let state = crate::tokio_util::spawn_blocking_cancellable_flatten(
             move |cancellable| -> Result<Box<LayeredImageState>> {
                 use cap_std_ext::rustix::fd::AsRawFd;
@@ -849,7 +848,7 @@ impl ImageImporter {
                 txn.commit(cancellable)?;
                 // Here we re-query state just to run through the same code path,
                 // though it'd be cheaper to synthesize it from the data we already have.
-                let state = query_image(repo, &imgref)?.unwrap();
+                let state = query_image_commit(repo, &merged_commit)?;
                 Ok(state)
             },
         )
@@ -878,11 +877,16 @@ pub fn query_image_ref(
 ) -> Result<Option<Box<LayeredImageState>>> {
     let ostree_ref = &ref_for_image(imgref)?;
     let merge_rev = repo.resolve_rev(ostree_ref, true)?;
-    let (merge_commit, merge_commit_obj) = if let Some(r) = merge_rev {
-        (r.to_string(), repo.load_commit(r.as_str())?.0)
-    } else {
-        return Ok(None);
-    };
+    merge_rev
+        .map(|r| query_image_commit(repo, r.as_str()))
+        .transpose()
+}
+
+/// Query metadata for a pulled image via an OSTree commit digest.
+/// The digest must refer to a pulled container image's merge commit.
+pub fn query_image_commit(repo: &ostree::Repo, commit: &str) -> Result<Box<LayeredImageState>> {
+    let merge_commit = commit.to_string();
+    let merge_commit_obj = repo.load_commit(commit)?.0;
     let commit_meta = &merge_commit_obj.child_value(0);
     let commit_meta = &ostree::glib::VariantDict::new(Some(commit_meta));
     let (manifest, manifest_digest) = manifest_data_from_commitmeta(commit_meta)?;
@@ -905,7 +909,7 @@ pub fn query_image_ref(
         configuration,
     });
     tracing::debug!(state = ?state);
-    Ok(Some(state))
+    Ok(state)
 }
 
 /// Query metadata for a pulled image.


### PR DESCRIPTION
Prep for better support for pruning.  An ostree deployment will retain a strong reference solely to a commit object; we can't rely on anything else.

I plan to use this in rpm-ostree to display metadata information about the container used for a deployment, even if the image reference has been pruned.