### PR TITLE
container: Add deployed commits into set of GC roots

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -252,6 +252,13 @@ pub(crate) enum ContainerImageOpts {
         skip_gc: bool,
     },
 
+    /// Garbage collect unreferenced image layer references.
+    PruneLayers {
+        /// Path to the repository
+        #[clap(long, value_parser)]
+        repo: Utf8PathBuf,
+    },
+
     /// Perform initial deployment for a container image
     Deploy {
         /// Path to the system root
@@ -775,6 +782,12 @@ where
                     } else {
                         println!("Removed images: {nimgs}");
                     }
+                    Ok(())
+                }
+                ContainerImageOpts::PruneLayers { repo } => {
+                    let repo = parse_repo(&repo)?;
+                    let nlayers = crate::container::store::gc_image_layers(&repo)?;
+                    println!("Removed layers: {nlayers}");
                     Ok(())
                 }
                 ContainerImageOpts::Copy {


### PR DESCRIPTION
Prep for handling image pruning better.  The way things are kind of expected to work today is that for a deployed ostree commit, we have *two* refs which point to it - one like e.g. `fedora:fedora/x86_64/coreos/stable`, as well as the "deployment ref" like "ostree/0/1/1" which is a synthetic ref generated by the sysroot core.

We want to be able to remove the container image refs - but doing so today subjects the *layer* branches to garbage collection.

Fix this by looking at the deployment refs as well as the set of images when computing the set of references for container images.