### PR TITLE
tar/import: Handle hardlinked changes into /sysroot

### DIFF
--- a/lib/src/tar/import.rs
+++ b/lib/src/tar/import.rs
@@ -27,7 +27,7 @@ const MAX_METADATA_SIZE: u32 = 10 * 1024 * 1024;
 pub(crate) const SMALL_REGFILE_SIZE: usize = 127 * 1024;
 
 // The prefix for filenames that contain content we actually look at.
-const REPO_PREFIX: &str = "sysroot/ostree/repo/";
+pub(crate) const REPO_PREFIX: &str = "sysroot/ostree/repo/";
 /// Statistics from import.
 #[derive(Debug, Default)]
 struct ImportStats {


### PR DESCRIPTION
Builds on https://github.com/ostreedev/ostree-rs-ext/pull/406

---

tar/import: Handle hardlinked changes into /sysroot

Some container build processes run without overlayfs inode indexing
on - in this common scenario, overlayfs is not quite POSIX compliant
because it will break the hardlink instead of modifying all versions.

We need to handle this case of having *all* names for a hardlinked
file being modified though too.  If the serialized tar stream
has the file in `/sysroot` be the canonical version, then because
we drop out that file here, we'll fail to import.

Fix this by significantly beefing up the tar filtering/reprocessing
logic:

 - When we see a *modified* file in `/sysroot` with a nonzero timestamp,
   cache its data into a lookaside temporary directory
 - If we then see a hardlink to that file path, make *that* file
   be the canonical version in e.g. `/usr`.
 - Any further hardlinks to `/sysroot` instead become hardlinks
   to the new canonical one.

(Arguably perhaps...we should actually not have used hardlinks
 in ostree containers at all, but injected this metadata in
 some other way.  But, the ship has sailed on that)

Closes: https://github.com/ostreedev/ostree-rs-ext/issues/405

---

