### PR TITLE
Add an isolation module, use it for pulls by default

### DIFF
--- a/lib/src/integrationtest.rs
+++ b/lib/src/integrationtest.rs
@@ -112,7 +112,11 @@ fn test_proxy_auth() -> Result<()> {
     std::fs::write(authpath, "{}")?;
     let mut c = ImageProxyConfig::default();
     merge(&mut c)?;
-    assert_eq!(c.authfile.unwrap().as_path(), authpath,);
+    if cap_std_ext::rustix::process::getuid().is_root() {
+        assert!(c.auth_data.is_some());
+    } else {
+        assert_eq!(c.authfile.unwrap().as_path(), authpath,);
+    }
     let c = ImageProxyConfig {
         auth_anonymous: true,
         ..Default::default()

--- a/lib/src/isolation.rs
+++ b/lib/src/isolation.rs
@@ -1,0 +1,44 @@
+use std::process::Command;
+
+use once_cell::sync::Lazy;
+
+pub(crate) const DEFAULT_UNPRIVILEGED_USER: &str = "nobody";
+
+/// Checks if the current process is (apparently at least)
+/// running under systemd.  We use this in various places
+/// to e.g. log to the journal instead of printing to stdout.
+pub(crate) fn running_in_systemd() -> bool {
+    static RUNNING_IN_SYSTEMD: Lazy<bool> = Lazy::new(|| {
+        // See https://www.freedesktop.org/software/systemd/man/systemd.exec.html#%24INVOCATION_ID
+        std::env::var_os("INVOCATION_ID")
+            .filter(|s| !s.is_empty())
+            .is_some()
+    });
+
+    *RUNNING_IN_SYSTEMD
+}
+
+/// Return a prepared subprocess configuration that will run as an unprivileged user if possible.
+///
+/// This currently only drops privileges when run under systemd with DynamicUser.
+pub(crate) fn unprivileged_subprocess(binary: &str, user: &str) -> Command {
+    // TODO: if we detect we're running in a container as uid 0, perhaps at least switch to the
+    // "bin" user if we can?
+    if !running_in_systemd() {
+        return Command::new(binary);
+    }
+    let mut cmd = Command::new("setpriv");
+    cmd.args(&[
+        "--no-new-privs",
+        "--init-groups",
+        "--reuid",
+        user,
+        "--bounding-set",
+        "-all",
+        "--pdeathsig",
+        "SIGTERM",
+        "--",
+        binary,
+    ]);
+    cmd
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -28,6 +28,8 @@ type Result<T> = anyhow::Result<T>;
 // Import global functions.
 mod globals;
 
+mod isolation;
+
 pub mod bootabletree;
 pub mod cli;
 pub mod container;


### PR DESCRIPTION
This effectively lowers into this project code from https://github.com/coreos/rpm-ostree/pull/3937/commits/d661e8f974f8d2550a865c2866476160e333ec72

We want to do this by default; we use the `nobody` user here.