### PR TITLE
container: Add support for copying optionally-present keys

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -126,6 +126,10 @@ pub(crate) enum ContainerOpts {
         #[clap(name = "copymeta", long)]
         copy_meta_keys: Vec<String>,
 
+        /// Propagate an optionally-present OSTree commit metadata key to container label
+        #[clap(name = "copymeta-opt", long)]
+        copy_meta_opt_keys: Vec<String>,
+
         /// Corresponds to the Dockerfile `CMD` instruction.
         #[clap(long)]
         cmd: Option<Vec<String>>,
@@ -531,12 +535,14 @@ async fn container_import(
 }
 
 /// Export a container image with an encapsulated ostree commit.
+#[allow(clippy::too_many_arguments)]
 async fn container_export(
     repo: &ostree::Repo,
     rev: &str,
     imgref: &ImageReference,
     labels: BTreeMap<String, String>,
     copy_meta_keys: Vec<String>,
+    copy_meta_opt_keys: Vec<String>,
     cmd: Option<Vec<String>>,
     compression_fast: bool,
 ) -> Result<()> {
@@ -546,6 +552,7 @@ async fn container_export(
     };
     let opts = crate::container::ExportOpts {
         copy_meta_keys,
+        copy_meta_opt_keys,
         skip_compression: compression_fast, // TODO rename this in the struct at the next semver break
         ..Default::default()
     };
@@ -723,6 +730,7 @@ where
                 imgref,
                 labels,
                 copy_meta_keys,
+                copy_meta_opt_keys,
                 cmd,
                 compression_fast,
             } => {
@@ -742,6 +750,7 @@ where
                     &imgref,
                     labels?,
                     copy_meta_keys,
+                    copy_meta_opt_keys,
                     cmd,
                     compression_fast,
                 )

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -525,6 +525,7 @@ async fn impl_test_container_import_export(
         .transpose()?;
     let opts = ExportOpts {
         copy_meta_keys: vec!["buildsys.checksum".to_string()],
+        copy_meta_opt_keys: vec!["nosuchvalue".to_string()],
         format: export_format,
         ..Default::default()
     };


### PR DESCRIPTION
This is to aid https://github.com/coreos/coreos-assembler/pull/3214 which is trying to inject the metadata key `fedora-coreos.stream` into the container image.  However, this value will only be present in Fedora derivatives, and not RHEL/CentOS.

Add support for copying a key only if present, instead of erroring if it's missing.