### PR TITLE
Add a `sysroot` module with helper for `SysrootLock`

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -37,6 +37,7 @@ pub mod ima;
 pub mod keyfileext;
 pub(crate) mod logging;
 pub mod refescape;
+pub mod sysroot;
 pub mod tar;
 pub mod tokio_util;
 

--- a/lib/src/sysroot.rs
+++ b/lib/src/sysroot.rs
@@ -1,0 +1,45 @@
+//! Helpers for interacting with sysroots.
+
+use std::ops::Deref;
+
+use anyhow::Result;
+
+/// A locked system root.
+#[derive(Debug)]
+pub struct SysrootLock {
+    sysroot: ostree::Sysroot,
+}
+
+impl Drop for SysrootLock {
+    fn drop(&mut self) {
+        self.sysroot.unlock();
+    }
+}
+
+impl Deref for SysrootLock {
+    type Target = ostree::Sysroot;
+
+    fn deref(&self) -> &Self::Target {
+        &self.sysroot
+    }
+}
+
+impl SysrootLock {
+    /// Asynchronously acquire a sysroot lock.  If the lock cannot be acquired
+    /// immediately, a status message will be printed to standard output.
+    pub async fn new_from_sysroot(sysroot: &ostree::Sysroot) -> Result<Self> {
+        let mut printed = false;
+        loop {
+            if sysroot.try_lock()? {
+                return Ok(Self {
+                    sysroot: sysroot.clone(),
+                });
+            }
+            if !printed {
+                println!("Waiting for sysroot lock...");
+                printed = true;
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        }
+    }
+}


### PR DESCRIPTION
A common use case is wanting to acquire a locked system root.  Add a helper function which handles this and returns a guard object that can be dereferenced to a sysroot.