### PR TITLE
ci/integration: `mkdir /var/tmp` for now

### DIFF
--- a/ci/ima.sh
+++ b/ci/ima.sh
@@ -4,6 +4,9 @@
 # Runs IMA tests.
 set -xeuo pipefail
 
+# https://github.com/ostreedev/ostree-rs-ext/issues/417
+mkdir -p /var/tmp
+
 if test '!' -x /usr/bin/evmctl; then
     rpm-ostree install ima-evm-utils
 fi


### PR DESCRIPTION
We should obviously fix this in a nicer way.
xref https://github.com/ostreedev/ostree-rs-ext/issues/417