### PR TITLE
Update MSRV, revamp CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,24 +15,22 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  # Minimum supported Rust version (MSRV)
-  ACTION_MSRV_TOOLCHAIN: 1.58.1
   # Pinned toolchain for linting
-  ACTION_LINTS_TOOLCHAIN: 1.58.1
+  ACTION_LINTS_TOOLCHAIN: 1.63.0
 
 jobs:
   tests:
     runs-on: ubuntu-latest
     container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Code lints
         run: ./ci/lints.sh
       - name: Install deps
         run: ./ci/installdeps.sh
       # xref containers/containers-image-proxy-rs
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
           key: "tests"
       - name: Build
@@ -47,11 +45,11 @@ jobs:
     runs-on: ubuntu-latest
     container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install deps
         run: ./ci/installdeps.sh
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
           key: "test-compat"
       - name: Build
@@ -62,11 +60,11 @@ jobs:
     runs-on: ubuntu-latest
     container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install deps
         run: ./ci/installdeps.sh
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
           key: "build"
       - name: Build
@@ -82,18 +80,23 @@ jobs:
     container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install deps
         run: ./ci/installdeps.sh
+      - name: Detect crate MSRV
+        shell: bash
+        run: |
+          msrv=$(cargo metadata --format-version 1 --no-deps | \
+              jq -r '.packages[1].rust_version')
+          echo "Crate MSRV: $msrv"
+          echo "ACTION_MSRV_TOOLCHAIN=$msrv" >> $GITHUB_ENV
       - name: Remove system Rust toolchain
         run: dnf remove -y rust cargo
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN']  }}
-          default: true
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
           key: "min"
       - name: cargo check
@@ -117,11 +120,9 @@ jobs:
         run: ./ci/installdeps.sh
       - name: Remove system Rust toolchain
         run: dnf remove -y rust cargo
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env['ACTION_LINTS_TOOLCHAIN']  }}
-          default: true
           components: rustfmt, clippy
       - name: cargo fmt (check)
         run: cargo fmt -- --check -l

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
 readme = "README.md"
 publish = false
+rust-version = "1.63.0"
 
 [dependencies]
 anyhow = "1.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -7,6 +7,7 @@ name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
 version = "0.9.1"
+rust-version = "1.63.0"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Prep for bumping ostree, which also bumps MSRV.

xref https://github.com/containers/containers-image-proxy-rs/pull/40/commits/12cdbf5af5ef40b312df14d7968e30bfbbb02067

- Use `checkout@v3` to avoid deprecation warnings
- switch to https://github.com/dtolnay/rust-toolchain after seeing https://www.reddit.com/r/rust/comments/z1mlls/actionsrs_github_actions_need_more_maintainers_or/
- bump to rust-cache@v2