### PR TITLE
tar/export: Always generate `/var/tmp`

### DIFF
--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -316,6 +316,7 @@ fn common_tar_contents_all() -> impl Iterator<Item = TarExpected> {
         ("usr/bin/bash", Link, 0o755),
         ("usr/bin/hardlink-a", Link, 0o644),
         ("usr/bin/hardlink-b", Link, 0o644),
+        ("var/tmp", Directory, 0o1777),
     ]
     .into_iter()
     .map(Into::into)

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -1289,12 +1289,7 @@ async fn test_old_code_parses_new_export() -> Result<()> {
         return Ok(());
     }
     let fixture = Fixture::new_v1()?;
-    let layout = if cfg!(feature = "compat") {
-        ExportLayout::V0
-    } else {
-        ExportLayout::V1
-    };
-    let imgref = fixture.export_container(layout).await?.0;
+    let imgref = fixture.export_container(ExportLayout::V1).await?.0;
     let imgref = OstreeImageReference {
         sigverify: SignatureSource::ContainerPolicyAllowInsecure,
         imgref,


### PR DESCRIPTION
This is a bit of a hack, but basically the ostree model of empty `/var` defers creation of basic directory structure to e.g. `systemd-tmpfiles`, but that isn't run in containers.

For now, let's keep this as the only special case.  Perhaps down the line we may actually need to effectively parse/execute systemd-tmpfiles inside the stream in the future, but hopefully we can avoid that.

Many things are going to use `/var/tmp` during image builds, but that's much less likely with e.g. `/var/log`.

Closes: https://github.com/ostreedev/ostree-rs-ext/issues/417