### PR TITLE
tests: Always use v1 for compat testing

### DIFF
--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -1289,12 +1289,7 @@ async fn test_old_code_parses_new_export() -> Result<()> {
         return Ok(());
     }
     let fixture = Fixture::new_v1()?;
-    let layout = if cfg!(feature = "compat") {
-        ExportLayout::V0
-    } else {
-        ExportLayout::V1
-    };
-    let imgref = fixture.export_container(layout).await?.0;
+    let imgref = fixture.export_container(ExportLayout::V1).await?.0;
     let imgref = OstreeImageReference {
         sigverify: SignatureSource::ContainerPolicyAllowInsecure,
         imgref,


### PR DESCRIPTION
With a new enough rpm-ostree, this test will always fail if we're built in compat mode.  I'm hitting this locally, but it looks like the latest rpm-ostree only made it to testing-devel 2 days ago.