### PR TITLE
Two minor bits

### DIFF
--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -224,17 +224,21 @@ impl std::fmt::Display for ImageReference {
     }
 }
 
-impl std::fmt::Display for OstreeImageReference {
+impl std::fmt::Display for SignatureSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.sigverify {
-            SignatureSource::OstreeRemote(r) => {
-                write!(f, "ostree-remote-image:{}:{}", r, self.imgref)
-            }
-            SignatureSource::ContainerPolicy => write!(f, "ostree-image-signed:{}", self.imgref),
+        match self {
+            SignatureSource::OstreeRemote(r) => write!(f, "ostree-remote-image:{r}"),
+            SignatureSource::ContainerPolicy => write!(f, "ostree-image-signed"),
             SignatureSource::ContainerPolicyAllowInsecure => {
-                write!(f, "ostree-unverified-image:{}", self.imgref)
+                write!(f, "ostree-unverified-image")
             }
         }
+    }
+}
+
+impl std::fmt::Display for OstreeImageReference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.sigverify, self.imgref)
     }
 }
 

--- a/lib/src/sysroot.rs
+++ b/lib/src/sysroot.rs
@@ -7,7 +7,8 @@ use anyhow::Result;
 /// A locked system root.
 #[derive(Debug)]
 pub struct SysrootLock {
-    sysroot: ostree::Sysroot,
+    /// The underlying sysroot value.
+    pub sysroot: ostree::Sysroot,
 }
 
 impl Drop for SysrootLock {


### PR DESCRIPTION
sysroot: Make underlying value `pub`

Since we expose it via `Deref` anyways.  Prep for usage in bootc.

---

impl Display for SignatureSource

This is the cleaner way to do things, and I want this in bootc.

---

