### PR TITLE
store: Tweak status message for layers

### DIFF
--- a/ci/priv-integration.sh
+++ b/ci/priv-integration.sh
@@ -58,7 +58,7 @@ echo "ok old image failed to parse"
 
 # Verify we have systemd journal messages
 nsenter -m -t 1 journalctl _COMM=ostree-ext-cli > logs.txt
-grep 'layers stored: ' logs.txt
+grep 'layers already present: ' logs.txt
 
 podman pull ${image}
 ostree --repo="${sysroot}/ostree/repo" init --mode=bare-user

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -250,7 +250,7 @@ impl PreparedImport {
                 });
         (to_fetch > 0).then(|| {
             let size = crate::glib::format_size(to_fetch_size);
-            format!("layers stored: {stored} needed: {to_fetch} ({size})")
+            format!("layers already present: {stored}; layers needed: {to_fetch} ({size})")
         })
     }
 }


### PR DESCRIPTION
The formatting was confusing before because one could associate the number both before and after "layers".