### PR TITLE
lib: Switch to olpc-cjson

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,7 +16,7 @@ async-compression = { version = "0.3", features = ["gzip", "tokio"] }
 bitflags = "1"
 camino = "1.0.4"
 chrono = "0.4.19"
-cjson = "0.1.1"
+olpc-cjson = "0.1.1"
 clap = { version= "3.2", features = ["derive"] }
 clap_mangen = { version = "0.1", optional = true }
 cap-std-ext = "1.0"


### PR DESCRIPTION
This is maintained as part of https://github.com/awslabs/tough and is used by several crates, including the pure Rust OCI crate https://lib.rs/crates/oci-distribution

The immediate motivation is dropping our duplicate `itoa` dep.