### PR TITLE
isolation: Avoid bug with `--pdeathsig SIGTERM` in Turkish locales

### DIFF
--- a/lib/src/isolation.rs
+++ b/lib/src/isolation.rs
@@ -36,7 +36,7 @@ pub(crate) fn unprivileged_subprocess(binary: &str, user: &str) -> Command {
         "--bounding-set",
         "-all",
         "--pdeathsig",
-        "SIGTERM",
+        "TERM",
         "--",
         binary,
     ]);


### PR DESCRIPTION
See https://github.com/coreos/rpm-ostree/issues/4237 for the original report.

Only in locales that use the dotless I case conversion we hit on the fact that util-linux uses `strcasecmp` which is locale-sensitive (It shouldn't be for this, because we're not accepting translated
 signal names.  It should be using an ASCII-only string comparison)

Anyways, we can work around this by omitting the leading `SIG` ourselves.