### PR TITLE
[0.8] backport gc

### DIFF
--- a/ci/priv-integration.sh
+++ b/ci/priv-integration.sh
@@ -7,8 +7,6 @@ set -euo pipefail
 sysroot=/run/host
 # Current stable image fixture
 image=quay.io/fedora/fedora-coreos:testing-devel
-# An unchunked v1 image
-old_image=quay.io/cgwalters/fcos:unchunked
 imgref=ostree-unverified-registry:${image}
 stateroot=testos
 
@@ -26,7 +24,7 @@ ostree-ext-cli container image deploy --sysroot "${sysroot}" \
 ostree admin --sysroot="${sysroot}" status
 ostree-ext-cli container image remove --repo "${sysroot}/ostree/repo" registry:"${image}"
 ostree admin --sysroot="${sysroot}" undeploy 0
-for img in "${image}" "${old_image}"; do
+for img in "${image}"; do
     ostree-ext-cli container image deploy --sysroot "${sysroot}" \
         --stateroot "${stateroot}" --imgref ostree-unverified-registry:"${img}"
     ostree admin --sysroot="${sysroot}" status

--- a/ci/priv-integration.sh
+++ b/ci/priv-integration.sh
@@ -30,8 +30,14 @@ for img in "${image}" "${old_image}"; do
     ostree-ext-cli container image deploy --sysroot "${sysroot}" \
         --stateroot "${stateroot}" --imgref ostree-unverified-registry:"${img}"
     ostree admin --sysroot="${sysroot}" status
+    initial_refs=$(ostree --repo="${sysroot}/ostree/repo" refs | wc -l)
     ostree-ext-cli container image remove --repo "${sysroot}/ostree/repo" registry:"${img}"
+    pruned_refs=$(ostree --repo="${sysroot}/ostree/repo" refs | wc -l)
+    # Removing the image should only drop the image reference, not its layers
+    test "$(($initial_refs - 1))" = "$pruned_refs"
     ostree admin --sysroot="${sysroot}" undeploy 0
+    # TODO: when we fold together ostree and ostree-ext, automatically prune layers
+    ostree-ext-cli container image prune-layers --repo="${sysroot}/ostree/repo"
     ostree --repo="${sysroot}/ostree/repo" refs > refs.txt
     if test "$(wc -l < refs.txt)" -ne 0; then
         echo "found refs"

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -252,6 +252,13 @@ enum ContainerImageOpts {
         skip_gc: bool,
     },
 
+    /// Garbage collect unreferenced image layer references.
+    PruneLayers {
+        /// Path to the repository
+        #[clap(long, value_parser)]
+        repo: Utf8PathBuf,
+    },
+
     /// Perform initial deployment for a container image
     Deploy {
         /// Path to the system root
@@ -757,6 +764,12 @@ where
                     } else {
                         println!("Removed images: {nimgs}");
                     }
+                    Ok(())
+                }
+                ContainerImageOpts::PruneLayers { repo } => {
+                    let repo = parse_repo(&repo)?;
+                    let nlayers = crate::container::store::gc_image_layers(&repo)?;
+                    println!("Removed layers: {nlayers}");
                     Ok(())
                 }
                 ContainerImageOpts::Copy {

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -976,6 +976,40 @@ pub async fn copy(
     Ok(())
 }
 
+/// Iterate over deployment commits, returning the manifests from
+/// commits which point to a container image.
+fn list_container_deployment_manifests(
+    repo: &ostree::Repo,
+    cancellable: Option<&gio::Cancellable>,
+) -> Result<Vec<ImageManifest>> {
+    let commits = repo
+        .list_refs_ext(
+            Some("ostree/0"),
+            ostree::RepoListRefsExtFlags::empty(),
+            cancellable,
+        )?
+        .into_iter()
+        .chain(repo.list_refs_ext(
+            Some("ostree/1"),
+            ostree::RepoListRefsExtFlags::empty(),
+            cancellable,
+        )?)
+        .map(|v| v.1);
+    let mut r = Vec::new();
+    for commit in commits {
+        let commit_obj = repo.load_commit(&commit)?.0;
+        let commit_meta = &glib::VariantDict::new(Some(&commit_obj.child_value(0)));
+        if commit_meta
+            .lookup::<String>(META_MANIFEST_DIGEST)?
+            .is_some()
+        {
+            let manifest = manifest_data_from_commitmeta(commit_meta)?.0;
+            r.push(manifest);
+        }
+    }
+    Ok(r)
+}
+
 /// Garbage collect unused image layer references.
 ///
 /// This function assumes no transaction is active on the repository.
@@ -991,11 +1025,13 @@ fn gc_image_layers_impl(
     cancellable: Option<&gio::Cancellable>,
 ) -> Result<u32> {
     let all_images = list_images(repo)?;
+    let deployment_commits = list_container_deployment_manifests(repo, cancellable)?;
     let all_manifests = all_images
         .into_iter()
         .map(|img| {
             ImageReference::try_from(img.as_str()).and_then(|ir| manifest_for_image(repo, &ir))
         })
+        .chain(deployment_commits.into_iter().map(Ok))
         .collect::<Result<Vec<_>>>()?;
     let mut referenced_layers = BTreeSet::new();
     for m in all_manifests.iter() {

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -132,7 +132,8 @@ pub struct ImageImporter {
     pub(crate) proxy: ImageProxy,
     imgref: OstreeImageReference,
     target_imgref: Option<OstreeImageReference>,
-    no_imgref: bool, // If true, do not write final image ref
+    no_imgref: bool,  // If true, do not write final image ref
+    disable_gc: bool, // If true, don't prune unused image layers
     pub(crate) proxy_img: OpenedImage,
 
     layer_progress: Option<Sender<ImportProgress>>,
@@ -440,6 +441,7 @@ impl ImageImporter {
             proxy_img,
             target_imgref: None,
             no_imgref: false,
+            disable_gc: false,
             imgref: imgref.clone(),
             layer_progress: None,
             layer_byte_progress: None,
@@ -456,6 +458,11 @@ impl ImageImporter {
     /// but in such a way that it does not need to be manually removed later.
     pub fn set_no_imgref(&mut self) {
         self.no_imgref = true;
+    }
+
+    /// Do not prune image layers.
+    pub fn disable_gc(&mut self) {
+        self.disable_gc = true;
     }
 
     /// Determine if there is a new manifest, and if so return its digest.
@@ -684,7 +691,9 @@ impl ImageImporter {
         })
     }
 
-    /// Import a layered container image
+    /// Import a layered container image.
+    ///
+    /// If enabled, this will also prune unused container image layers.
     #[context("Importing")]
     pub async fn import(
         mut self,
@@ -840,6 +849,12 @@ impl ImageImporter {
                     repo.transaction_set_ref(None, &ostree_ref, Some(merged_commit.as_str()));
                 }
                 txn.commit(cancellable)?;
+
+                if !self.disable_gc {
+                    let n: u32 = gc_image_layers_impl(repo, cancellable)?;
+                    tracing::debug!("pruned {n} layers");
+                }
+
                 // Here we re-query state just to run through the same code path,
                 // though it'd be cheaper to synthesize it from the data we already have.
                 let state = query_image(repo, &imgref)?.unwrap();
@@ -963,7 +978,14 @@ pub async fn copy(
 /// The underlying objects are *not* pruned; that requires a separate invocation
 /// of [`ostree::Repo::prune`].
 pub fn gc_image_layers(repo: &ostree::Repo) -> Result<u32> {
-    let cancellable = gio::NONE_CANCELLABLE;
+    gc_image_layers_impl(repo, gio::NONE_CANCELLABLE)
+}
+
+#[context("Pruning image layers")]
+fn gc_image_layers_impl(
+    repo: &ostree::Repo,
+    cancellable: Option<&gio::Cancellable>,
+) -> Result<u32> {
     let all_images = list_images(repo)?;
     let all_manifests = all_images
         .into_iter()
@@ -996,6 +1018,20 @@ pub fn gc_image_layers(repo: &ostree::Repo) -> Result<u32> {
     }
 
     Ok(pruned)
+}
+
+#[cfg(feature = "internal-testing-api")]
+/// Return how many container blobs (layers) are stored
+pub fn count_layer_references(repo: &ostree::Repo) -> Result<u32> {
+    let cancellable = gio::NONE_CANCELLABLE;
+    let n = repo
+        .list_refs_ext(
+            Some(LAYER_PREFIX),
+            ostree::RepoListRefsExtFlags::empty(),
+            cancellable,
+        )?
+        .len();
+    Ok(n as u32)
 }
 
 #[context("Pruning {}", image)]

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -1074,17 +1074,6 @@ pub fn count_layer_references(repo: &ostree::Repo) -> Result<u32> {
     Ok(n as u32)
 }
 
-#[context("Pruning {}", image)]
-fn prune_image(repo: &ostree::Repo, image: &ImageReference) -> Result<()> {
-    let ostree_ref = &ref_for_image(image)?;
-
-    if repo.resolve_rev(ostree_ref, true)?.is_none() {
-        anyhow::bail!("No such image");
-    }
-    repo.set_ref_immediate(None, ostree_ref, None, gio::NONE_CANCELLABLE)?;
-    Ok(())
-}
-
 /// Given an image, if it has any non-ostree compatible content, return a suitable
 /// warning message.
 pub fn image_filtered_content_warning(
@@ -1118,7 +1107,26 @@ pub fn image_filtered_content_warning(
     Ok(r)
 }
 
-/// Remove the specified image references.
+/// Remove the specified image reference.  If the image is already
+/// not present, this function will successfully perform no operation.
+///
+/// This function assumes no transaction is active on the repository.
+/// The underlying layers are *not* pruned; that requires a separate invocation
+/// of [`gc_image_layers`].
+#[context("Pruning {img}")]
+pub fn remove_image(repo: &ostree::Repo, img: &ImageReference) -> Result<bool> {
+    let ostree_ref = &ref_for_image(img)?;
+    let found = repo.resolve_rev(ostree_ref, true)?.is_some();
+    // Note this API is already idempotent, but we might as well avoid another
+    // trip into ostree.
+    if found {
+        repo.set_ref_immediate(None, ostree_ref, None, gio::NONE_CANCELLABLE)?;
+    }
+    Ok(found)
+}
+
+/// Remove the specified image references.  If an image is not found, further
+/// images will be removed, but an error will be returned.
 ///
 /// This function assumes no transaction is active on the repository.
 /// The underlying layers are *not* pruned; that requires a separate invocation
@@ -1127,8 +1135,19 @@ pub fn remove_images<'a>(
     repo: &ostree::Repo,
     imgs: impl IntoIterator<Item = &'a ImageReference>,
 ) -> Result<()> {
+    let mut missing = Vec::new();
     for img in imgs.into_iter() {
-        prune_image(repo, img)?;
+        let found = remove_image(repo, img)?;
+        if !found {
+            missing.push(img);
+        }
+    }
+    if !missing.is_empty() {
+        let missing = missing.into_iter().fold("".to_string(), |mut a, v| {
+            a.push_str(&v.to_string());
+            a
+        });
+        return Err(anyhow::anyhow!("Missing images: {missing}"));
     }
     Ok(())
 }

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -773,7 +773,6 @@ impl ImageImporter {
 
         // Destructure to transfer ownership to thread
         let repo = self.repo;
-        let imgref = self.target_imgref.unwrap_or(self.imgref);
         let state = crate::tokio_util::spawn_blocking_cancellable_flatten(
             move |cancellable| -> Result<Box<LayeredImageState>> {
                 use cap_std_ext::rustix::fd::AsRawFd;
@@ -857,7 +856,7 @@ impl ImageImporter {
 
                 // Here we re-query state just to run through the same code path,
                 // though it'd be cheaper to synthesize it from the data we already have.
-                let state = query_image(repo, &imgref)?.unwrap();
+                let state = query_image_commit(repo, &merged_commit)?;
                 Ok(state)
             },
         )
@@ -886,11 +885,16 @@ pub fn query_image_ref(
 ) -> Result<Option<Box<LayeredImageState>>> {
     let ostree_ref = &ref_for_image(imgref)?;
     let merge_rev = repo.resolve_rev(ostree_ref, true)?;
-    let (merge_commit, merge_commit_obj) = if let Some(r) = merge_rev {
-        (r.to_string(), repo.load_commit(r.as_str())?.0)
-    } else {
-        return Ok(None);
-    };
+    merge_rev
+        .map(|r| query_image_commit(repo, r.as_str()))
+        .transpose()
+}
+
+/// Query metadata for a pulled image via an OSTree commit digest.
+/// The digest must refer to a pulled container image's merge commit.
+pub fn query_image_commit(repo: &ostree::Repo, commit: &str) -> Result<Box<LayeredImageState>> {
+    let merge_commit = commit.to_string();
+    let merge_commit_obj = repo.load_commit(commit)?.0;
     let commit_meta = &merge_commit_obj.child_value(0);
     let commit_meta = &ostree::glib::VariantDict::new(Some(commit_meta));
     let (manifest, manifest_digest) = manifest_data_from_commitmeta(commit_meta)?;
@@ -913,7 +917,7 @@ pub fn query_image_ref(
         configuration,
     });
     tracing::debug!(state = ?state);
-    Ok(Some(state))
+    Ok(state)
 }
 
 /// Query metadata for a pulled image.

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -795,12 +795,14 @@ r usr/bin/bash bash-v0
         }
     }
 
+    assert_eq!(store::list_images(fixture.destrepo()).unwrap().len(), 1);
+    let n = store::count_layer_references(fixture.destrepo())? as i64;
     let _import = imp.import(prep).await.unwrap();
 
     assert_eq!(store::list_images(fixture.destrepo()).unwrap().len(), 1);
 
-    let n_removed = store::gc_image_layers(fixture.destrepo())?;
-    assert_eq!(n_removed, 2);
+    let n2 = store::count_layer_references(fixture.destrepo())? as i64;
+    assert_eq!(n, n2);
     fixture
         .destrepo()
         .prune(ostree::RepoPruneFlags::REFS_ONLY, 0, gio::NONE_CANCELLABLE)?;
@@ -841,6 +843,8 @@ r usr/bin/bash bash-v0
     assert!(prep.ostree_commit_layer.commit.is_some());
     assert_eq!(prep.ostree_layers.len(), nlayers as usize);
 
+    // We want to test explicit layer pruning
+    imp.disable_gc();
     let _import = imp.import(prep).await.unwrap();
     assert_eq!(store::list_images(fixture.destrepo()).unwrap().len(), 2);
 
@@ -864,6 +868,7 @@ r usr/bin/bash bash-v0
     assert_eq!(n_removed, (*CONTENTS_V0_LEN + 1) as u32);
 
     // Repo should be clean now
+    assert_eq!(store::count_layer_references(fixture.destrepo())?, 0);
     assert_eq!(
         fixture
             .destrepo()

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -857,7 +857,9 @@ r usr/bin/bash bash-v0
     // Should only be new layers
     let n_removed = store::gc_image_layers(fixture.destrepo())?;
     assert_eq!(n_removed, 0);
-    store::remove_images(fixture.destrepo(), [&imgref.imgref]).unwrap();
+    // Also test idempotence
+    store::remove_image(fixture.destrepo(), &imgref.imgref).unwrap();
+    store::remove_image(fixture.destrepo(), &imgref.imgref).unwrap();
     assert_eq!(store::list_images(fixture.destrepo()).unwrap().len(), 1);
     // Still no removed layers after removing the base image
     let n_removed = store::gc_image_layers(fixture.destrepo())?;


### PR DESCRIPTION
Depends https://github.com/ostreedev/ostree-rs-ext/pull/443

This backports the GC work to the (new) 0.8 branch.  Thankfully it was all clean cherry :cherries: picks!

--- 

Remove test parsing old export

The newer rpm-ostree we ship now no longer supports it.  We
aren't going to change anything in the export path on this
branch, so we don't need it.

---

tests: Update to non-deprecated chrono API

The deprecation was introduced in a new chrono release and
is triggering our clippy lints.

(cherry picked from commit 7875bb33ab37807c1cf3f0ca96297d28c1ea0feb)

---

ci: Retarget for this branch

---

container: Prune image layers by default

A while ago we added APIs to do this, but we should really
do it by default when fetching upgraded images.  Otherwise
we effectively leak space.

(cherry picked from commit 97d8d3ded5ff2c02b49d6e3085d9b0fef5feae9d)

---

container: Add an API to query information from a commit object

Prep for better support for pruning.  An ostree deployment
will retain a strong reference solely to a commit object; we can't
rely on anything else.

I plan to use this in rpm-ostree to display metadata information
about the container used for a deployment, even if the
image reference has been pruned.

(cherry picked from commit ee502e54549797161afc57f885c7c4acbc67b07e)

---

container: Add deployed commits into set of GC roots

Prep for handling image pruning better.  The way things
are kind of expected to work today is that for a deployed ostree
commit, we have *two* refs which point to it - one like e.g.
`fedora:fedora/x86_64/coreos/stable`, as well as the "deployment ref"
like "ostree/0/1/1" which is a synthetic ref generated by the
sysroot core.

We want to be able to remove the container image refs - but
doing so today subjects the *layer* branches to garbage collection.

Fix this by looking at the deployment refs as well as the set of
images when computing the set of references for container images.

(cherry picked from commit aec69c8171d797176c795dbd9c2a434b2d5c785e)

---

container: Make single image removal idempotent

Due to bugs or logic errors, it's possible that we might attempt
to prune an image that's already been pruned.  In order to
make things more robust, let's avoid making this a hard error.

Keep the semantics for the existing "prune multiple images" API,
but add a new one that prunes a singular image, and does not
error in the not-found case.  This can be used by higher level
software.

(cherry picked from commit f1af4f34147e43edbcf831198fb09fba0c3c6141)

---

