### PR TITLE
container/store: Write final commit with timestamp

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -151,7 +151,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: quay.io/fedora/fedora-coreos:testing-devel
-      options: "--privileged --pid=host -v /run/systemd:/run/systemd -v /:/run/host"
+      options: "--privileged --pid=host -v /var/tmp:/var/tmp -v /run/dbus:/run/dbus -v /run/systemd:/run/systemd -v /:/run/host"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -52,6 +52,8 @@ pub(crate) mod objgv;
 #[cfg(feature = "internal-testing-api")]
 pub mod ostree_manual;
 
+mod utils;
+
 #[cfg(feature = "docgen")]
 mod docgen;
 

--- a/lib/src/utils.rs
+++ b/lib/src/utils.rs
@@ -1,0 +1,34 @@
+pub(crate) trait ResultExt<T, E: std::fmt::Display> {
+    /// Return the Ok value unchanged.  In the err case, log it, and call the closure to compute the default
+    fn log_err_or_else<F>(self, default: F) -> T
+    where
+        F: FnOnce() -> T;
+    /// Return the Ok value unchanged.  In the err case, log it, and return the default value
+    fn log_err_default(self) -> T
+    where
+        T: Default;
+}
+
+impl<T, E: std::fmt::Display> ResultExt<T, E> for Result<T, E> {
+    #[track_caller]
+    fn log_err_or_else<F>(self, default: F) -> T
+    where
+        F: FnOnce() -> T,
+    {
+        match self {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::debug!("{e}");
+                default()
+            }
+        }
+    }
+
+    #[track_caller]
+    fn log_err_default(self) -> T
+    where
+        T: Default,
+    {
+        self.log_err_or_else(|| Default::default())
+    }
+}


### PR DESCRIPTION
I was doing some bootc tests and noticed that the deployment commit was different each time I ran an install.  Write the commit with the timestamp of the config (or manifest) to increase reproducibility.