### PR TITLE
two error prefixing patches

### DIFF
--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -554,6 +554,7 @@ impl ImageImporter {
     }
 
     /// Extract the base ostree commit.
+    #[context("Unencapsulating base")]
     pub(crate) async fn unencapsulate_base(
         &mut self,
         import: &mut store::PreparedImport,
@@ -643,7 +644,9 @@ impl ImageImporter {
                     let mut importer = crate::tar::Importer::new_for_commit(&repo, remote);
                     let blob = tokio_util::io::SyncIoBridge::new(blob);
                     let mut archive = tar::Archive::new(blob);
-                    importer.import_commit(&mut archive, Some(cancellable))?;
+                    importer
+                        .import_commit(&mut archive, Some(cancellable))
+                        .context("Importing commit layer")?;
                     let commit = importer.finish_import_commit();
                     if write_refs {
                         repo.transaction_set_ref(None, &target_ref, Some(commit.as_str()));

--- a/lib/src/tar/import.rs
+++ b/lib/src/tar/import.rs
@@ -670,12 +670,14 @@ impl Importer {
 
             // Now that we have both the commit and detached metadata in memory, verify that
             // the signatures in the detached metadata correctly sign the commit.
-            self.repo.signature_verify_commit_data(
-                remote,
-                &commit.data_as_bytes(),
-                &commitmeta.data_as_bytes(),
-                ostree::RepoVerifyFlags::empty(),
-            )?;
+            self.repo
+                .signature_verify_commit_data(
+                    remote,
+                    &commit.data_as_bytes(),
+                    &commitmeta.data_as_bytes(),
+                    ostree::RepoVerifyFlags::empty(),
+                )
+                .context("Verifying ostree commit in tar stream")?;
 
             self.repo.mark_commit_partial(&checksum, true)?;
 


### PR DESCRIPTION
tar: Add error prefixing around commit verification

In an error message we got a bare
`error: No such remote ...`
Let's clarify where this is coming from.

---

store: Add error prefixing on base import

On general principle; we got a "bare errors" in the case of
a missing ostree remote.

---

