### PR TITLE
container: Add an API to retrieve the version number

### DIFF
--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -208,6 +208,11 @@ impl PreparedImport {
             .chain(self.layers.iter())
     }
 
+    /// Retrieve the container image version.
+    pub fn version(&self) -> Option<&str> {
+        super::version_for_config(&self.config)
+    }
+
     /// If this image is using any deprecated features, return a message saying so.
     pub fn deprecated_warning(&self) -> Option<&'static str> {
         match self.export_layout {
@@ -343,7 +348,7 @@ pub(crate) fn parse_manifest_layout<'a>(
     Vec<&'a Descriptor>,
     Vec<&'a Descriptor>,
 )> {
-    let config_labels = config.config().as_ref().and_then(|c| c.labels().as_ref());
+    let config_labels = super::labels_of(config);
     let bootable_key = *ostree::METADATA_KEY_BOOTABLE;
     let bootable = config_labels.map_or(false, |l| l.contains_key(bootable_key));
     if !bootable {

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -689,6 +689,7 @@ async fn impl_test_container_chunked(format: ExportLayout) -> Result<()> {
         prep.deprecated_warning().is_some()
     );
     assert_eq!(prep.export_layout, format);
+    assert_eq!(prep.version(), Some("42.0"));
     let digest = prep.manifest_digest.clone();
     assert!(prep.ostree_commit_layer.commit.is_none());
     assert_eq!(prep.ostree_layers.len(), nlayers as usize);


### PR DESCRIPTION
This makes it more convenient for higher level tools to display the associated image version number.

Closes: https://github.com/ostreedev/ostree-rs-ext/issues/450