### PR TITLE
tests: Trim some v0 export format code

### DIFF
--- a/lib/src/fixture.rs
+++ b/lib/src/fixture.rs
@@ -3,7 +3,7 @@
 #![allow(missing_docs)]
 
 use crate::chunking::ObjectMetaSized;
-use crate::container::{Config, ExportLayout, ExportOpts, ImageReference, Transport};
+use crate::container::{Config, ExportOpts, ImageReference, Transport};
 use crate::objectsource::{ObjectMeta, ObjectSourceMeta};
 use crate::prelude::*;
 use crate::{gio, glib};
@@ -632,14 +632,8 @@ impl Fixture {
     /// Export the current ref as a container image.
     /// This defaults to using chunking.
     #[context("Exporting container")]
-    pub async fn export_container(
-        &self,
-        export_format: ExportLayout,
-    ) -> Result<(ImageReference, String)> {
-        let name = match export_format {
-            ExportLayout::V0 => "oci-v0",
-            ExportLayout::V1 => "oci-v1",
-        };
+    pub async fn export_container(&self) -> Result<(ImageReference, String)> {
+        let name = "oci-v1";
         let container_path = &self.path.join(name);
         if container_path.exists() {
             std::fs::remove_dir_all(container_path)?;
@@ -660,10 +654,7 @@ impl Fixture {
         let contentmeta = self.get_object_meta().context("Computing object meta")?;
         let contentmeta = ObjectMetaSized::compute_sizes(self.srcrepo(), contentmeta)
             .context("Computing sizes")?;
-        let opts = ExportOpts {
-            format: export_format,
-            ..Default::default()
-        };
+        let opts = ExportOpts::default();
         let digest = crate::container::encapsulate(
             self.srcrepo(),
             self.testref(),

--- a/lib/src/integrationtest.rs
+++ b/lib/src/integrationtest.rs
@@ -2,11 +2,7 @@
 
 use std::path::Path;
 
-use crate::{
-    container::{ocidir, ExportLayout},
-    container_utils::is_ostree_container,
-    ocidir::RawLayerWriter,
-};
+use crate::{container::ocidir, container_utils::is_ostree_container, ocidir::RawLayerWriter};
 use anyhow::Result;
 use camino::Utf8Path;
 use cap_std::fs::Dir;
@@ -134,10 +130,8 @@ fn test_proxy_auth() -> Result<()> {
 /// Useful for debugging things interactively.
 pub(crate) async fn create_fixture() -> Result<()> {
     let fixture = crate::fixture::Fixture::new_v1()?;
-    for format in [ExportLayout::V0, ExportLayout::V1] {
-        let imgref = fixture.export_container(format).await?.0;
-        println!("Wrote: {:?}", imgref);
-    }
+    let imgref = fixture.export_container().await?.0;
+    println!("Wrote: {:?}", imgref);
     let path = fixture.into_tempdir().into_path();
     println!("Wrote: {:?}", path);
     Ok(())

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -656,15 +656,12 @@ fn validate_chunked_structure(oci_path: &Utf8Path, format: ExportLayout) -> Resu
 }
 
 #[tokio::test]
-async fn test_container_chunked_v1() -> Result<()> {
-    impl_test_container_chunked(ExportLayout::V1).await
-}
-
-async fn impl_test_container_chunked(format: ExportLayout) -> Result<()> {
+async fn test_container_chunked() -> Result<()> {
+    let format = ExportLayout::V1;
     let nlayers = *CONTENTS_V0_LEN - 1;
     let mut fixture = Fixture::new_v1()?;
 
-    let (imgref, expected_digest) = fixture.export_container(format).await.unwrap();
+    let (imgref, expected_digest) = fixture.export_container().await.unwrap();
     let imgref = OstreeImageReference {
         sigverify: SignatureSource::ContainerPolicyAllowInsecure,
         imgref,
@@ -714,7 +711,7 @@ r usr/bin/bash bash-v0
         .update(FileDef::iter_from(ADDITIONS), std::iter::empty())
         .context("Failed to update")?;
 
-    let expected_digest = fixture.export_container(format).await.unwrap().1;
+    let expected_digest = fixture.export_container().await.unwrap().1;
     assert_ne!(digest, expected_digest);
 
     let mut imp =
@@ -731,20 +728,8 @@ r usr/bin/bash bash-v0
     let (first, second) = (to_fetch[0], to_fetch[1]);
     assert!(first.0.commit.is_none());
     assert!(second.0.commit.is_none());
-    match format {
-        ExportLayout::V0 => {
-            assert_eq!(first.1, "bash");
-            assert!(
-                second.1.starts_with("ostree export of commit"),
-                "{}",
-                second.1
-            );
-        }
-        ExportLayout::V1 => {
-            assert_eq!(first.1, "testlink");
-            assert_eq!(second.1, "bash");
-        }
-    }
+    assert_eq!(first.1, "testlink");
+    assert_eq!(second.1, "bash");
 
     assert_eq!(store::list_images(fixture.destrepo()).unwrap().len(), 1);
     let n = store::count_layer_references(fixture.destrepo())? as i64;
@@ -838,7 +823,7 @@ r usr/bin/bash bash-v0
 async fn test_container_var_content() -> Result<()> {
     let fixture = Fixture::new_v1()?;
 
-    let imgref = fixture.export_container(ExportLayout::V1).await.unwrap().0;
+    let imgref = fixture.export_container().await.unwrap().0;
     let imgref = OstreeImageReference {
         sigverify: SignatureSource::ContainerPolicyAllowInsecure,
         imgref,
@@ -1129,7 +1114,7 @@ async fn test_container_write_derive() -> Result<()> {
 #[tokio::test]
 async fn test_container_write_derive_sysroot_hardlink() -> Result<()> {
     let fixture = Fixture::new_v1()?;
-    let baseimg = &fixture.export_container(ExportLayout::V1).await?.0;
+    let baseimg = &fixture.export_container().await?.0;
     let basepath = &match baseimg.transport {
         Transport::OciDir => fixture.path.join(baseimg.name.as_str()),
         _ => unreachable!(),
@@ -1222,7 +1207,7 @@ async fn test_old_code_parses_new_export() -> Result<()> {
         return Ok(());
     }
     let fixture = Fixture::new_v1()?;
-    let imgref = fixture.export_container(ExportLayout::V1).await?.0;
+    let imgref = fixture.export_container().await?.0;
     let imgref = OstreeImageReference {
         sigverify: SignatureSource::ContainerPolicyAllowInsecure,
         imgref,


### PR DESCRIPTION
We're not supporting this anymore; continue to trim it from our tests.

(There's even more to do here, but this compiles)