### PR TITLE
Release 0.10.5

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
-version = "0.10.4"
+version = "0.10.5"
 rust-version = "1.63.0"
 
 [dependencies]


### PR DESCRIPTION
Mainly to get the new version APIs out for use in bootc/rpm-ostree.