### PR TITLE
Release 0.10.6

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
-version = "0.10.5"
+version = "0.10.6"
 rust-version = "1.63.0"
 
 [dependencies]


### PR DESCRIPTION
Two new APIs, and we now also inject the standard OCI version annotation.