### PR TITLE
Release 0.10.7

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
-version = "0.10.6"
+version = "0.10.7"
 rust-version = "1.63.0"
 
 [dependencies]


### PR DESCRIPTION
Colin Walters (5):
      ci: We can now pull from containers-storage
      deploy: Make `--stateroot` default to `default`
      deploy: Add optional `--image` syntax
      container/store: Add a well-known ref for holding base images
      Release 0.10.7