### PR TITLE
Update to ostree 0.18

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # Pinned toolchain for linting
-  ACTION_LINTS_TOOLCHAIN: 1.63.0
+  ACTION_LINTS_TOOLCHAIN: 1.64.0
 
 jobs:
   tests:

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
 readme = "README.md"
 publish = false
-rust-version = "1.63.0"
+rust-version = "1.64.0"
 
 [dependencies]
 anyhow = "1.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -33,7 +33,7 @@ libc = "0.2.92"
 libsystemd = "0.5.0"
 oci-spec = "0.5.4"
 openssl = "0.10.33"
-ostree = { features = ["v2022_5", "cap-std-apis"], version = "0.17.0" }
+ostree = { features = ["v2022_5", "cap-std-apis"], version = "0.18.0" }
 pin-project = "1.0"
 regex = "1.5.4"
 serde = { features = ["derive"], version = "1.0.125" }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -7,7 +7,7 @@ name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
 version = "0.10.7"
-rust-version = "1.63.0"
+rust-version = "1.64.0"
 
 [dependencies]
 anyhow = "1.0"

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -871,7 +871,7 @@ where
                 } => {
                     let sysroot = &ostree::Sysroot::new(Some(&gio::File::for_path(&sysroot)));
                     sysroot.load(gio::Cancellable::NONE)?;
-                    let repo = &sysroot.repo().unwrap();
+                    let repo = &sysroot.repo();
                     let kargs = karg.as_deref();
                     let kargs = kargs.map(|v| {
                         let r: Vec<_> = v.iter().map(|s| s.as_str()).collect();

--- a/lib/src/container/deploy.rs
+++ b/lib/src/container/deploy.rs
@@ -51,7 +51,7 @@ pub async fn deploy(
 ) -> Result<Box<LayeredImageState>> {
     let cancellable = ostree::gio::Cancellable::NONE;
     let options = options.unwrap_or_default();
-    let repo = &sysroot.repo().unwrap();
+    let repo = &sysroot.repo();
     let merge_deployment = sysroot.merge_deployment(Some(stateroot));
     let mut imp =
         super::store::ImageImporter::new(repo, imgref, options.proxy_cfg.unwrap_or_default())

--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -315,7 +315,7 @@ pub fn merge_default_container_proxy_opts(
 ) -> Result<()> {
     let user = cap_std_ext::rustix::process::getuid()
         .is_root()
-        .then(|| isolation::DEFAULT_UNPRIVILEGED_USER);
+        .then_some(isolation::DEFAULT_UNPRIVILEGED_USER);
     merge_default_container_proxy_opts_with_isolation(config, user)
 }
 
@@ -341,7 +341,7 @@ pub fn merge_default_container_proxy_opts_with_isolation(
     let isolation_user = config
         .skopeo_cmd
         .is_none()
-        .then(|| isolation_user.as_ref())
+        .then_some(isolation_user.as_ref())
         .flatten();
     if let Some(user) = isolation_user {
         // Read the default authfile if it exists and pass it via file descriptor

--- a/lib/src/diff.rs
+++ b/lib/src/diff.rs
@@ -101,21 +101,20 @@ fn diff_recurse(
             from_child.ensure_resolved()?;
 
             if is_dir {
-                let from_contents_checksum =
-                    from_child.tree_get_contents_checksum().expect("checksum");
-                let to_contents_checksum = to_child.tree_get_contents_checksum().expect("checksum");
+                let from_contents_checksum = from_child.tree_get_contents_checksum();
+                let to_contents_checksum = to_child.tree_get_contents_checksum();
                 if from_contents_checksum != to_contents_checksum {
                     let subpath = format!("{}/", path);
                     diff_recurse(&subpath, diff, &from_child, &to_child)?;
                 }
-                let from_meta_checksum = from_child.tree_get_metadata_checksum().expect("checksum");
-                let to_meta_checksum = to_child.tree_get_metadata_checksum().expect("checksum");
+                let from_meta_checksum = from_child.tree_get_metadata_checksum();
+                let to_meta_checksum = to_child.tree_get_metadata_checksum();
                 if from_meta_checksum != to_meta_checksum {
                     diff.changed_dirs.insert(path);
                 }
             } else {
-                let from_checksum = from_child.checksum().expect("checksum");
-                let to_checksum = to_child.checksum().expect("checksum");
+                let from_checksum = from_child.checksum();
+                let to_checksum = to_child.checksum();
                 if from_checksum != to_checksum {
                     diff.changed_files.insert(path);
                 }

--- a/lib/src/fixture.rs
+++ b/lib/src/fixture.rs
@@ -241,7 +241,7 @@ pub fn create_dirmeta(path: &Utf8Path, selinux: bool) -> glib::Variant {
         None
     };
     let xattrs = label.map(|v| v.new_xattrs());
-    ostree::create_directory_metadata(&finfo, xattrs.as_ref()).unwrap()
+    ostree::create_directory_metadata(&finfo, xattrs.as_ref())
 }
 
 /// Wraps [`create_dirmeta`] and commits it.
@@ -320,7 +320,7 @@ fn build_mapping_recurse(
                     });
                 }
 
-                let checksum = child.checksum().unwrap().to_string();
+                let checksum = child.checksum().to_string();
                 match ret.map.entry(checksum) {
                     Entry::Vacant(v) => {
                         v.insert(owner);

--- a/lib/src/tar/import.rs
+++ b/lib/src/tar/import.rs
@@ -752,7 +752,7 @@ impl Importer {
         finfo.set_attribute_uint32("unix::gid", 0);
         finfo.set_attribute_uint32("unix::mode", libc::S_IFDIR | 0o755);
         // SAFETY: TODO: This is not a nullable return, fix it in ostree
-        ostree::create_directory_metadata(&finfo, None).unwrap()
+        ostree::create_directory_metadata(&finfo, None)
     }
 
     pub(crate) fn finish_import_object_set(self) -> Result<String> {


### PR DESCRIPTION
This adapts to the changes from https://github.com/ostreedev/ostree/pull/2791 in particular.

---

Bump MSRV to 1.64

Since it's what ostree requires now, due to one of its dependencies.

---

