### PR TITLE
Use `oci_spec` re-exported from `containers_image_proxy`

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.64.0"
 
 [dependencies]
 anyhow = "1.0"
-containers-image-proxy = "0.5.2"
+containers-image-proxy = "0.5.3"
 async-compression = { version = "0.3", features = ["gzip", "tokio"] }
 bitflags = "1"
 camino = "1.0.4"
@@ -31,7 +31,6 @@ indicatif = "0.17.0"
 once_cell = "1.9"
 libc = "0.2.92"
 libsystemd = "0.5.0"
-oci-spec = "0.5.4"
 openssl = "0.10.33"
 ostree = { features = ["v2022_5", "cap-std-apis"], version = "0.18.0" }
 pin-project = "1.0"

--- a/lib/src/container/encapsulate.rs
+++ b/lib/src/container/encapsulate.rs
@@ -9,6 +9,7 @@ use crate::tar as ostree_tar;
 use anyhow::{anyhow, Context, Result};
 use cap_std::fs::Dir;
 use cap_std_ext::cap_std;
+use containers_image_proxy::oci_spec;
 use flate2::Compression;
 use fn_error_context::context;
 use gio::glib;

--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -26,8 +26,9 @@
 //! for this is [planned but not implemented](https://github.com/ostreedev/ostree-rs-ext/issues/12).
 
 use anyhow::anyhow;
-
+use containers_image_proxy::oci_spec;
 use ostree::glib;
+
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ops::Deref;

--- a/lib/src/container/ocidir.rs
+++ b/lib/src/container/ocidir.rs
@@ -9,6 +9,7 @@ use camino::Utf8Path;
 use cap_std::fs::Dir;
 use cap_std_ext::cap_std;
 use cap_std_ext::dirext::CapStdExtDirExt;
+use containers_image_proxy::oci_spec;
 use flate2::write::GzEncoder;
 use fn_error_context::context;
 use oci_image::MediaType;

--- a/lib/src/container/update_detachedmeta.rs
+++ b/lib/src/container/update_detachedmeta.rs
@@ -5,6 +5,7 @@ use anyhow::{anyhow, Context, Result};
 use camino::Utf8Path;
 use cap_std::fs::Dir;
 use cap_std_ext::cap_std;
+use containers_image_proxy::oci_spec;
 use std::io::{BufReader, BufWriter};
 
 /// Given an OSTree container image reference, update the detached metadata (e.g. GPG signature)

--- a/lib/src/integrationtest.rs
+++ b/lib/src/integrationtest.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use camino::Utf8Path;
 use cap_std::fs::Dir;
 use cap_std_ext::cap_std;
+use containers_image_proxy::oci_spec;
 use fn_error_context::context;
 use gio::prelude::*;
 use oci_spec::image as oci_image;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -16,7 +16,7 @@
 // Re-export our dependencies.  See https://gtk-rs.org/blog/2021/06/22/new-release.html
 // "Dependencies are re-exported".  Users will need e.g. `gio::File`, so this avoids
 // them needing to update matching versions.
-pub use oci_spec;
+pub use containers_image_proxy::oci_spec;
 pub use ostree;
 pub use ostree::gio;
 pub use ostree::gio::glib;

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use camino::Utf8Path;
 use cap_std::fs::{Dir, DirBuilder};
+use containers_image_proxy::oci_spec;
 use once_cell::sync::Lazy;
 use ostree::cap_std;
 use ostree_ext::chunking::ObjectMetaSized;


### PR DESCRIPTION
This needs to stay in sync, because it's a public API dependency of that project.  Motivated by a recent semver bump there.