### PR TITLE
chunking: Deduplicate the config history for each layer

### DIFF
--- a/lib/src/chunking.rs
+++ b/lib/src/chunking.rs
@@ -300,7 +300,7 @@ impl Chunking {
                 0 => unreachable!(),
                 1 => Cow::Borrowed(first_name),
                 2..=5 => {
-                    let r = bin.iter().map(|v| &*v.meta.name).fold(
+                    let r = bin.iter().map(|v| &*v.meta.name).skip(1).fold(
                         String::from(first_name),
                         |mut acc, v| {
                             write!(acc, " and {}", v).unwrap();


### PR DESCRIPTION
Followup: https://github.com/ostreedev/ostree-rs-ext/pull/456#discussion_r1180747811
Fix the the repeated name of the first package in the history of oci config for each oci layer