### PR TITLE
tests: Port to xshell

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -46,7 +46,7 @@ tokio-stream = { features = ["sync"], version = "0.1.8" }
 tracing = "0.1"
 
 indoc = { version = "1.0.3", optional = true }
-sh-inline = { version = "0.4", features = ["cap-std-ext"], optional = true }
+xshell = { version = "0.2", optional = true }
 
 [dev-dependencies]
 quickcheck = "1"
@@ -60,4 +60,4 @@ features = ["dox"]
 [features]
 docgen = ["clap_mangen"]
 dox = ["ostree/dox"]
-internal-testing-api = ["sh-inline", "indoc"]
+internal-testing-api = ["xshell", "indoc"]

--- a/lib/src/fixture.rs
+++ b/lib/src/fixture.rs
@@ -415,6 +415,12 @@ impl Fixture {
         &self.destrepo
     }
 
+    pub fn new_shell(&self) -> Result<xshell::Shell> {
+        let sh = xshell::Shell::new()?;
+        sh.change_dir(&self.path);
+        Ok(sh)
+    }
+
     // Delete all objects in the destrepo
     pub fn clear_destrepo(&self) -> Result<()> {
         self.destrepo()


### PR DESCRIPTION
This is better than my own `sh-inline` crate:

- It properly supports variable capture from the Rust context which is way more ergonomic
- There's higher level helper functions too that allow reading/writing files relative to the context directory
- It doesn't depend on cap-std-ext, and we need to bump the semver there
- It's maintained by someone else
- It has more users