### PR TITLE
Bump to cap-std-ext 2.0, use rustix directly

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -19,7 +19,7 @@ chrono = "0.4.19"
 olpc-cjson = "0.1.1"
 clap = { version= "3.2", features = ["derive"] }
 clap_mangen = { version = "0.1", optional = true }
-cap-std-ext = "1.0"
+cap-std-ext = "2.0"
 cap-tempfile = "1.0"
 flate2 = { features = ["zlib"], default_features = false, version = "1.0.20" }
 fn-error-context = "0.2.0"
@@ -35,6 +35,7 @@ openssl = "0.10.33"
 ostree = { features = ["v2022_5", "cap-std-apis"], version = "0.18.0" }
 pin-project = "1.0"
 regex = "1.5.4"
+rustix = { version = "0.37.19", features = ["fs", "process"] }
 serde = { features = ["derive"], version = "1.0.125" }
 serde_json = "1.0.64"
 tar = "0.4.38"

--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -9,7 +9,7 @@ use camino::Utf8Path;
 use cap_std::fs::Dir;
 use cap_std_ext::cap_std;
 use cap_std_ext::dirext::CapStdExtDirExt;
-use cap_std_ext::rustix::fs::MetadataExt;
+use rustix::fs::MetadataExt;
 use std::borrow::Cow;
 use std::convert::TryInto;
 use std::path::Path;

--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -314,7 +314,7 @@ impl ManifestDiff {
 pub fn merge_default_container_proxy_opts(
     config: &mut containers_image_proxy::ImageProxyConfig,
 ) -> Result<()> {
-    let user = cap_std_ext::rustix::process::getuid()
+    let user = rustix::process::getuid()
         .is_root()
         .then_some(isolation::DEFAULT_UNPRIVILEGED_USER);
     merge_default_container_proxy_opts_with_isolation(config, user)

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -799,7 +799,7 @@ impl ImageImporter {
         let repo = self.repo;
         let state = crate::tokio_util::spawn_blocking_cancellable_flatten(
             move |cancellable| -> Result<Box<LayeredImageState>> {
-                use cap_std_ext::rustix::fd::AsRawFd;
+                use rustix::fd::AsRawFd;
 
                 let cancellable = Some(cancellable);
                 let repo = &repo;

--- a/lib/src/globals.rs
+++ b/lib/src/globals.rs
@@ -1,7 +1,6 @@
 //! Global functions.
 
 use super::Result;
-use cap_std_ext::rustix;
 use once_cell::sync::OnceCell;
 use ostree::glib;
 use std::fs::File;

--- a/lib/src/ima.rs
+++ b/lib/src/ima.rs
@@ -5,7 +5,6 @@
 use crate::objgv::*;
 use anyhow::{Context, Result};
 use camino::Utf8PathBuf;
-use cap_std_ext::rustix::fd::BorrowedFd;
 use fn_error_context::context;
 use gio::glib;
 use gio::prelude::*;
@@ -14,6 +13,7 @@ use glib::Variant;
 use gvariant::aligned_bytes::TryAsAligned;
 use gvariant::{gv, Marker, Structure};
 use ostree::gio;
+use rustix::fd::BorrowedFd;
 use std::collections::{BTreeMap, HashMap};
 use std::ffi::CString;
 use std::fs::File;

--- a/lib/src/integrationtest.rs
+++ b/lib/src/integrationtest.rs
@@ -110,7 +110,7 @@ fn test_proxy_auth() -> Result<()> {
     std::fs::write(authpath, "{}")?;
     let mut c = ImageProxyConfig::default();
     merge(&mut c)?;
-    if cap_std_ext::rustix::process::getuid().is_root() {
+    if rustix::process::getuid().is_root() {
         assert!(c.auth_data.is_some());
     } else {
         assert_eq!(c.authfile.unwrap().as_path(), authpath,);

--- a/lib/src/selinux.rs
+++ b/lib/src/selinux.rs
@@ -1,7 +1,6 @@
 //! SELinux-related helper APIs.
 
 use anyhow::Result;
-use cap_std_ext::rustix;
 use fn_error_context::context;
 use std::path::Path;
 


### PR DESCRIPTION
In cap-std-ext we made the mistake of making rustix a public API; the 2.0 version fixes that.

Add rustix directly here and use it.