### PR TITLE
container: Move ManifestDiff to use a constructor

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -935,7 +935,8 @@ where
             } => {
                 let (manifest_old, _) = crate::container::fetch_manifest(&imgref_old).await?;
                 let (manifest_new, _) = crate::container::fetch_manifest(&imgref_new).await?;
-                let manifest_diff = crate::container::manifest_diff(&manifest_old, &manifest_new);
+                let manifest_diff =
+                    crate::container::ManifestDiff::new(&manifest_old, &manifest_new);
                 manifest_diff.print();
                 Ok(())
             }


### PR DESCRIPTION
In Rust the norm is to use a `fn new` for these types of things.

Just going over our public API and looking for improvements.