### PR TITLE
tree-wide: Run cargo clippy --fix

### DIFF
--- a/lib/src/chunking.rs
+++ b/lib/src/chunking.rs
@@ -311,7 +311,7 @@ impl Chunking {
                 }
                 n => Cow::Owned(format!("{n} components")),
             };
-            let mut chunk = Chunk::new(&*name);
+            let mut chunk = Chunk::new(&name);
             for szmeta in bin {
                 for &obj in rmap.get(&szmeta.meta.identifier).unwrap() {
                     self.remainder.move_obj(&mut chunk, obj.as_str());

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -659,7 +659,7 @@ async fn container_history(repo: &ostree::Repo, imgref: &ImageReference) -> Resu
         {
             let mut remaining = width;
             for (name, width) in columns.iter() {
-                print_column(name, *width as usize, &mut remaining);
+                print_column(name, *width, &mut remaining);
             }
             println!();
         }

--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -91,7 +91,7 @@ fn remove_all_on_mount_recurse(root: &Dir, rootdev: u64, path: &Path) -> Result<
         }
     }
     if !skipped {
-        root.remove_dir(&path)?;
+        root.remove_dir(path)?;
     }
     Ok(skipped)
 }
@@ -207,8 +207,8 @@ mod tests {
         assert!(td.try_exists(var)?);
         assert!(!td.try_exists(&systemd)?);
 
-        td.remove_dir_all(&var)?;
-        td.create_dir(&var)?;
+        td.remove_dir_all(var)?;
+        td.create_dir(var)?;
         td.write(var.join("foo"), "somefile")?;
         assert!(prepare_ostree_commit_in(td).is_err());
         // Right now we don't auto-create var/tmp if it didn't exist, but maybe
@@ -221,7 +221,7 @@ mod tests {
         assert!(td.try_exists(var)?);
 
         let nested = Utf8Path::new("var/lib/nested");
-        td.create_dir_all(&nested)?;
+        td.create_dir_all(nested)?;
         td.write(nested.join("foo"), "test1")?;
         td.write(nested.join("foo2"), "test2")?;
         assert!(prepare_ostree_commit_in(td).is_err());

--- a/lib/src/container/encapsulate.rs
+++ b/lib/src/container/encapsulate.rs
@@ -85,6 +85,7 @@ fn commit_meta_to_labels<'a>(
     }
     // Copy standard metadata keys `ostree.bootable` and `ostree.linux`.
     // Bootable is an odd one out in being a boolean.
+    #[allow(clippy::explicit_auto_deref)]
     if let Some(v) = meta.lookup::<bool>(*ostree::METADATA_KEY_BOOTABLE)? {
         labels.insert(ostree::METADATA_KEY_BOOTABLE.to_string(), v.to_string());
     }

--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -353,7 +353,7 @@ pub fn merge_default_container_proxy_opts_with_isolation(
         // Read the default authfile if it exists and pass it via file descriptor
         // which will ensure it's readable when we drop privileges.
         if let Some(authfile) = config.authfile.take() {
-            config.auth_data = Some(std::fs::File::open(&authfile)?);
+            config.auth_data = Some(std::fs::File::open(authfile)?);
         }
         let cmd = crate::isolation::unprivileged_subprocess("skopeo", user);
         config.skopeo_cmd = Some(cmd);
@@ -510,8 +510,10 @@ mod tests {
         assert!(c.skopeo_cmd.is_none());
 
         // Verify interaction with explicit isolation
-        let mut c = ImageProxyConfig::default();
-        c.skopeo_cmd = Some(Command::new("skopeo"));
+        let mut c = ImageProxyConfig {
+            skopeo_cmd: Some(Command::new("skopeo")),
+            ..Default::default()
+        };
         super::merge_default_container_proxy_opts_with_isolation(&mut c, Some("foo")).unwrap();
         assert_eq!(c.skopeo_cmd.unwrap().get_program(), "skopeo");
     }

--- a/lib/src/container/ocidir.rs
+++ b/lib/src/container/ocidir.rs
@@ -256,7 +256,7 @@ impl OciDir {
     pub fn read_blob(&self, desc: &oci_spec::image::Descriptor) -> Result<File> {
         let path = Self::parse_descriptor_to_path(desc)?;
         self.dir
-            .open(&path)
+            .open(path)
             .map_err(Into::into)
             .map(|f| f.into_std())
     }

--- a/lib/src/diff.rs
+++ b/lib/src/diff.rs
@@ -90,7 +90,7 @@ fn diff_recurse(
         let name = from_info.name();
         let name = name.to_str().expect("UTF-8 ostree name");
         let path = format!("{prefix}{name}");
-        let to_child = to.child(&name);
+        let to_child = to.child(name);
         let to_info = query_info_optional(&to_child, queryattrs, queryflags)
             .context("querying optional to")?;
         let is_dir = matches!(from_info.file_type(), gio::FileType::Directory);

--- a/lib/src/fixture.rs
+++ b/lib/src/fixture.rs
@@ -386,7 +386,7 @@ impl Fixture {
         let st = std::process::Command::new("tar")
             .cwd_dir(gpghome)
             .stdin(Stdio::from(gpgtar))
-            .args(&["-azxf", "-"])
+            .args(["-azxf", "-"])
             .status()?;
         assert!(st.success());
 

--- a/lib/src/fixture.rs
+++ b/lib/src/fixture.rs
@@ -496,6 +496,7 @@ impl Fixture {
         );
         metadata.insert("ostree.container-cmd", &vec!["/usr/bin/bash"]);
         metadata.insert("version", &"42.0");
+        #[allow(clippy::explicit_auto_deref)]
         metadata.insert(*ostree::METADATA_KEY_BOOTABLE, &true);
         let metadata = metadata.to_variant();
         let commit = self.srcrepo.write_commit_with_time(

--- a/lib/src/ima.rs
+++ b/lib/src/ima.rs
@@ -132,8 +132,8 @@ impl<'a> CommitRewriter<'a> {
         proc.current_dir(self.tempdir.path())
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
-            .args(&["ima_sign", "--xattr-user", "--key", self.ima.key.as_str()])
-            .args(&["--hashalgo", self.ima.algorithm.as_str()])
+            .args(["ima_sign", "--xattr-user", "--key", self.ima.key.as_str()])
+            .args(["--hashalgo", self.ima.algorithm.as_str()])
             .arg(tempf.path().file_name().unwrap());
         let status = proc.output().context("Spawning evmctl")?;
         if !status.status.success() {

--- a/lib/src/isolation.rs
+++ b/lib/src/isolation.rs
@@ -28,7 +28,7 @@ pub(crate) fn unprivileged_subprocess(binary: &str, user: &str) -> Command {
         return Command::new(binary);
     }
     let mut cmd = Command::new("setpriv");
-    cmd.args(&[
+    cmd.args([
         "--no-new-privs",
         "--init-groups",
         "--reuid",

--- a/lib/src/objectsource.rs
+++ b/lib/src/objectsource.rs
@@ -70,7 +70,7 @@ impl Hash for ObjectSourceMeta {
 
 impl Borrow<str> for ObjectSourceMeta {
     fn borrow(&self) -> &str {
-        &*self.identifier
+        &self.identifier
     }
 }
 

--- a/lib/src/tar/export.rs
+++ b/lib/src/tar/export.rs
@@ -171,7 +171,7 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
         h.set_gid(0);
         h.set_mode(0o755);
         h.set_size(0);
-        self.out.append_data(&mut h, &path, &mut std::io::empty())?;
+        self.out.append_data(&mut h, path, &mut std::io::empty())?;
         Ok(())
     }
 
@@ -188,7 +188,7 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
         h.set_gid(0);
         h.set_mode(0o644);
         h.set_size(0);
-        self.out.append_link(&mut h, &path, &link_target)?;
+        self.out.append_link(&mut h, path, link_target)?;
         Ok(())
     }
 
@@ -488,7 +488,7 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
                 let (objpath, h) = self.append_content(checksum)?;
                 let subpath = &dirpath.join(name);
                 let subpath = map_path(subpath);
-                self.append_content_hardlink(&objpath, h, &*subpath)?;
+                self.append_content_hardlink(&objpath, h, &subpath)?;
             }
         }
 
@@ -517,8 +517,8 @@ impl<'a, W: std::io::Write> OstreeTarWriter<'a, W> {
             let dirtree_csum = hex::encode(contents_csum);
             let subpath = &dirpath.join(name);
             let subpath = map_path(subpath);
-            self.append_dir(&*subpath, &metadata)?;
-            self.append_dirtree(&*subpath, dirtree_csum, false, cancellable)?;
+            self.append_dir(&subpath, &metadata)?;
+            self.append_dirtree(&subpath, dirtree_csum, false, cancellable)?;
         }
 
         Ok(())
@@ -671,7 +671,7 @@ pub(crate) fn reinject_detached_metadata<C: IsA<gio::Cancellable>>(
     }
     let commit_ent = commit_ent.ok_or_else(|| anyhow!("Missing commit object"))?;
     let commit_path = commit_ent.path()?;
-    let commit_path = Utf8Path::from_path(&*commit_path)
+    let commit_path = Utf8Path::from_path(&commit_path)
         .ok_or_else(|| anyhow!("Invalid non-utf8 path {:?}", commit_path))?;
     let (checksum, objtype) = crate::tar::import::Importer::parse_metadata_entry(commit_path)?;
     assert_eq!(objtype, ostree::ObjectType::Commit); // Should have been verified above

--- a/lib/src/tar/import.rs
+++ b/lib/src/tar/import.rs
@@ -198,7 +198,7 @@ impl Importer {
             return Ok(None);
         }
         let orig_path = e.path()?;
-        let path = Utf8Path::from_path(&*orig_path)
+        let path = Utf8Path::from_path(&orig_path)
             .ok_or_else(|| anyhow!("Invalid non-utf8 path {:?}", orig_path))?;
         // Ignore the regular non-object file hardlinks we inject
         if let Ok(path) = path.strip_prefix(REPO_PREFIX) {
@@ -475,7 +475,7 @@ impl Importer {
                 let link_target = entry
                     .link_name()?
                     .ok_or_else(|| anyhow!("No xattrs link content for {}", checksum))?;
-                let xattr_target = Utf8Path::from_path(&*link_target)
+                let xattr_target = Utf8Path::from_path(&link_target)
                     .ok_or_else(|| anyhow!("Invalid non-UTF8 xattrs link {}", checksum))?;
                 parse_xattrs_link_target(xattr_target)?
             }
@@ -515,7 +515,7 @@ impl Importer {
         let xattr_target = entry
             .link_name()?
             .ok_or_else(|| anyhow!("No xattrs link content for {}", target))?;
-        let xattr_target = Utf8Path::from_path(&*xattr_target)
+        let xattr_target = Utf8Path::from_path(&xattr_target)
             .ok_or_else(|| anyhow!("Invalid non-UTF8 xattrs link {}", target))?;
         let xattr_target = xattr_target
             .file_name()

--- a/lib/src/tar/write.rs
+++ b/lib/src/tar/write.rs
@@ -299,7 +299,7 @@ pub async fn write_tar(
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .args(&["commit"]);
+            .args(["commit"]);
         c.take_fd_n(repofd.clone(), 3);
         c.arg("--repo=/proc/self/fd/3");
         if let Some(sepolicy) = sepolicy.as_ref() {
@@ -310,7 +310,7 @@ pub async fn write_tar(
             "--add-metadata-string=ostree.importer.version={}",
             env!("CARGO_PKG_VERSION")
         ));
-        c.args(&[
+        c.args([
             "--no-bindings",
             "--tar-autocreate-parents",
             "--tree=tar=/proc/self/fd/0",

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -434,7 +434,7 @@ async fn test_tar_write_tar_layer() -> Result<()> {
 
 fn skopeo_inspect(imgref: &str) -> Result<String> {
     let out = Command::new("skopeo")
-        .args(&["inspect", imgref])
+        .args(["inspect", imgref])
         .stdout(std::process::Stdio::piped())
         .output()?;
     Ok(String::from_utf8(out.stdout)?)
@@ -442,7 +442,7 @@ fn skopeo_inspect(imgref: &str) -> Result<String> {
 
 fn skopeo_inspect_config(imgref: &str) -> Result<oci_spec::image::ImageConfiguration> {
     let out = Command::new("skopeo")
-        .args(&["inspect", "--config", imgref])
+        .args(["inspect", "--config", imgref])
         .stdout(std::process::Stdio::piped())
         .output()?;
     Ok(serde_json::from_slice(&out.stdout)?)
@@ -685,7 +685,7 @@ async fn test_container_chunked() -> Result<()> {
     assert_eq!(prep.version(), Some("42.0"));
     let digest = prep.manifest_digest.clone();
     assert!(prep.ostree_commit_layer.commit.is_none());
-    assert_eq!(prep.ostree_layers.len(), nlayers as usize);
+    assert_eq!(prep.ostree_layers.len(), nlayers);
     assert_eq!(prep.layers.len(), 0);
     for layer in prep.layers.iter() {
         assert!(layer.commit.is_none());
@@ -721,7 +721,7 @@ r usr/bin/bash bash-v0
     assert_eq!(to_fetch.len(), 2);
     assert_eq!(expected_digest, prep.manifest_digest.as_str());
     assert!(prep.ostree_commit_layer.commit.is_none());
-    assert_eq!(prep.ostree_layers.len(), nlayers as usize);
+    assert_eq!(prep.ostree_layers.len(), nlayers);
     let (first, second) = (to_fetch[0], to_fetch[1]);
     assert!(first.0.commit.is_none());
     assert!(second.0.commit.is_none());
@@ -774,7 +774,7 @@ r usr/bin/bash bash-v0
     let to_fetch = prep.layers_to_fetch().collect::<Result<Vec<_>>>()?;
     assert_eq!(to_fetch.len(), 1);
     assert!(prep.ostree_commit_layer.commit.is_some());
-    assert_eq!(prep.ostree_layers.len(), nlayers as usize);
+    assert_eq!(prep.ostree_layers.len(), nlayers);
 
     // We want to test explicit layer pruning
     imp.disable_gc();
@@ -875,8 +875,8 @@ async fn oci_clone(src: impl AsRef<Utf8Path>, dest: impl AsRef<Utf8Path>) -> Res
     // For now we just fork off `cp` and rely on reflinks, but we could and should
     // explicitly hardlink blobs/sha256 e.g.
     let cmd = tokio::process::Command::new("cp")
-        .args(&["-a", "--reflink=auto"])
-        .args(&[src, dest])
+        .args(["-a", "--reflink=auto"])
+        .args([src, dest])
         .status()
         .await?;
     if !cmd.success() {
@@ -920,7 +920,7 @@ async fn test_container_write_derive() -> Result<()> {
     let derived_path = &fixture.path.join("derived.oci");
     oci_clone(base_oci_path, derived_path).await?;
     let temproot = &fixture.path.join("temproot");
-    std::fs::create_dir_all(&temproot.join("usr/bin"))?;
+    std::fs::create_dir_all(temproot.join("usr/bin"))?;
     let newderivedfile_contents = "newderivedfile v0";
     std::fs::write(
         temproot.join("usr/bin/newderivedfile"),
@@ -944,7 +944,7 @@ async fn test_container_write_derive() -> Result<()> {
     let derived2_path = &fixture.path.join("derived2.oci");
     oci_clone(base_oci_path, derived2_path).await?;
     std::fs::remove_dir_all(temproot)?;
-    std::fs::create_dir_all(&temproot.join("usr/bin"))?;
+    std::fs::create_dir_all(temproot.join("usr/bin"))?;
     std::fs::write(temproot.join("usr/bin/newderivedfile"), "newderivedfile v1")?;
     std::fs::write(
         temproot.join("usr/bin/newderivedfile2"),
@@ -1204,7 +1204,7 @@ async fn test_container_write_derive_sysroot_hardlink() -> Result<()> {
         },
     };
     let mut imp =
-        store::ImageImporter::new(fixture.destrepo(), &derived_ref, Default::default()).await?;
+        store::ImageImporter::new(fixture.destrepo(), derived_ref, Default::default()).await?;
     let prep = match imp.prepare().await.context("Init prep derived")? {
         store::PrepareResult::AlreadyPresent(_) => panic!("should not be already imported"),
         store::PrepareResult::Ready(r) => r,
@@ -1247,7 +1247,7 @@ async fn test_old_code_parses_new_export() -> Result<()> {
     fixture.clear_destrepo()?;
     let destrepo_path = fixture.path.join("dest/repo");
     let s = Command::new("ostree")
-        .args(&[
+        .args([
             "container",
             "unencapsulate",
             "--repo",


### PR DESCRIPTION
tests: One run of `cargo clippy --fix`

Nothing important, just some unnecessary `&` churn.

---

lib: Ignore incorrect clippy lint about deref+`Lazy`

`cargo clippy --fix` fails to compile if we remove the `*` here.

---

tree-wide: Run `cargo clippy --fix`

Nothing important here, just the usual spam of unnecessary `&`
basically.

---

