### PR TITLE
Two minor test additions

### DIFF
--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -691,6 +691,25 @@ async fn test_container_chunked() -> Result<()> {
         assert!(layer.commit.is_none());
     }
     assert_eq!(digest, expected_digest);
+    {
+        let mut layer_history = prep.layers_with_history();
+        assert!(layer_history
+            .next()
+            .unwrap()?
+            .1
+            .created_by()
+            .as_ref()
+            .unwrap()
+            .starts_with("ostree export"));
+        assert!(layer_history
+            .nth(6)
+            .unwrap()?
+            .1
+            .created_by()
+            .as_ref()
+            .unwrap()
+            .starts_with("testlink"));
+    }
     let import = imp.import(prep).await.context("Init pull derived").unwrap();
     assert_eq!(import.manifest_digest.as_str(), digest);
 

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -691,7 +691,8 @@ async fn test_container_chunked() -> Result<()> {
         assert!(layer.commit.is_none());
     }
     assert_eq!(digest, expected_digest);
-    let _import = imp.import(prep).await.context("Init pull derived").unwrap();
+    let import = imp.import(prep).await.context("Init pull derived").unwrap();
+    assert_eq!(import.manifest_digest.as_str(), digest);
 
     assert_eq!(store::list_images(fixture.destrepo()).unwrap().len(), 1);
 


### PR DESCRIPTION
tests: Also verify manifest digest

Just a drive by cleanup; unused variables are usually a red flag.
Let's just add an assertion here.

---

tests: Add a test for layers_with_history()

Motivated by https://github.com/ostreedev/ostree-rs-ext/issues/480

---

