### PR TITLE
tests: Drop legacy image test

### DIFF
--- a/ci/priv-integration.sh
+++ b/ci/priv-integration.sh
@@ -10,7 +10,6 @@ mkdir -p /var/tmp
 sysroot=/run/host
 # Current stable image fixture
 image=quay.io/fedora/fedora-coreos:testing-devel
-old_image=quay.io/cgwalters/fcos:unchunked
 imgref=ostree-unverified-registry:${image}
 stateroot=testos
 
@@ -57,14 +56,6 @@ for img in "${image}"; do
         exit 1
     fi
 done
-
-if ostree-ext-cli container image deploy --sysroot "${sysroot}" \
-        --stateroot "${stateroot}" --imgref ostree-unverified-registry:"${old_image}" 2>err.txt; then
-    echo "deployed old image"
-    exit 1
-fi
-grep 'legacy format.*no longer supported' err.txt
-echo "ok old image failed to parse"
 
 # Verify we have systemd journal messages
 nsenter -m -t 1 journalctl _COMM=ostree-ext-cli > logs.txt


### PR DESCRIPTION
I cleaned up my quay.io namespace and obviously didn't realize/remember that we were using an image from my namespace in our tests.

While we could recreate it, it doesn't seem worth it.  Just drop the test.