### PR TITLE
Release 0.11.0

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
-version = "0.10.7"
+version = "0.11.0"
 rust-version = "1.64.0"
 
 [dependencies]


### PR DESCRIPTION
(We should have bumped the semver in git before now)

But I think we're done with API changes for now, so let's go ahead and do the first 0.11 release.