### PR TITLE
store: Pulling from container-storage needs root privileges

### DIFF
--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -441,8 +441,13 @@ impl ImageImporter {
         imgref: &OstreeImageReference,
         mut config: ImageProxyConfig,
     ) -> Result<Self> {
-        // Apply our defaults to the proxy config
-        merge_default_container_proxy_opts(&mut config)?;
+        if imgref.imgref.transport == Transport::ContainerStorage {
+            // Fetching from containers-storage, may require privileges to read files
+            merge_default_container_proxy_opts_with_isolation(&mut config, None)?;
+        } else {
+            // Apply our defaults to the proxy config
+            merge_default_container_proxy_opts(&mut config)?;
+        }
         let proxy = ImageProxy::new_with_config(config).await?;
 
         system_repo_journal_print(


### PR DESCRIPTION
Fixes: https://github.com/coreos/rpm-ostree/issues/4283