### PR TITLE
deploy: Add an API to prune undeployed images

### DIFF
--- a/ci/priv-integration.sh
+++ b/ci/priv-integration.sh
@@ -24,6 +24,8 @@ fi
 if test '!' -d "${sysroot}/ostree/deploy/${stateroot}"; then
     ostree admin os-init "${stateroot}" --sysroot "${sysroot}"
 fi
+# Should be no images pruned
+ostree-ext-cli container image prune-images --sysroot "${sysroot}"
 # Test the syntax which uses full imgrefs.
 ostree-ext-cli container image deploy --sysroot "${sysroot}" \
     --stateroot "${stateroot}" --imgref "${imgref}"
@@ -34,8 +36,11 @@ ostree admin --sysroot="${sysroot}" undeploy 0
 ostree-ext-cli container image deploy --transport registry --sysroot "${sysroot}" \
     --stateroot "${stateroot}" --image "${image}" --no-signature-verification
 ostree admin --sysroot="${sysroot}" status
-ostree-ext-cli container image remove --repo "${sysroot}/ostree/repo" registry:"${image}"
 ostree admin --sysroot="${sysroot}" undeploy 0
+# Now we should prune it
+ostree-ext-cli container image prune-images --sysroot "${sysroot}"
+ostree-ext-cli container image list --repo "${sysroot}/ostree/repo" > out.txt
+test $(stat -c '%s' out.txt) = 0
 
 for img in "${image}"; do
     ostree-ext-cli container image deploy --sysroot "${sysroot}" \

--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -48,7 +48,7 @@ pub(crate) const COMPONENT_SEPARATOR: char = ',';
 type Result<T> = anyhow::Result<T>;
 
 /// A backend/transport for OCI/Docker images.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Hash, Debug, PartialEq, Eq)]
 pub enum Transport {
     /// A remote Docker/OCI registry (`registry:` or `docker://`)
     Registry,
@@ -63,7 +63,7 @@ pub enum Transport {
 /// Combination of a remote image reference and transport.
 ///
 /// For example,
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct ImageReference {
     /// The storage and transport for the image
     pub transport: Transport,
@@ -72,7 +72,7 @@ pub struct ImageReference {
 }
 
 /// Policy for signature verification.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SignatureSource {
     /// Fetches will use the named ostree remote for signature verification of the ostree commit.
     OstreeRemote(String),
@@ -87,7 +87,7 @@ pub const LABEL_VERSION: &str = "version";
 
 /// Combination of a signature verification mechanism, and a standard container image reference.
 ///
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct OstreeImageReference {
     /// The signature verification mechanism.
     pub sigverify: SignatureSource,


### PR DESCRIPTION
This is part of fixing https://github.com/coreos/rpm-ostree/issues/4391 but is also in the general theme of making things less "stateful".

A huge huge mess today is `rpm-ostree rebase` and `bootc switch` both have `--retain` options which keep the previous image.

But really what we want is to use the deployments as source-of-truth; that way if e.g. an admin pins a deployment, it automatically pins the image too.

And this will help strongly align with the bootc direction in reconciling to desired state.