### PR TITLE
deploy: Don't overwrite kargs by default

### DIFF
--- a/lib/src/container/deploy.rs
+++ b/lib/src/container/deploy.rs
@@ -81,11 +81,12 @@ pub async fn deploy(
     let target_imgref = options.target_imgref.unwrap_or(imgref);
     origin.set_string("origin", ORIGIN_CONTAINER, &target_imgref.to_string());
 
+    let opts = ostree::SysrootDeployTreeOpts {
+        override_kernel_argv: options.kargs,
+        ..Default::default()
+    };
+
     if sysroot.booted_deployment().is_some() {
-        let opts = ostree::SysrootDeployTreeOpts {
-            override_kernel_argv: options.kargs,
-            ..Default::default()
-        };
         sysroot.stage_tree_with_options(
             Some(stateroot),
             commit,
@@ -95,12 +96,12 @@ pub async fn deploy(
             cancellable,
         )?;
     } else {
-        let deployment = &sysroot.deploy_tree(
+        let deployment = &sysroot.deploy_tree_with_options(
             Some(stateroot),
             commit,
             Some(&origin),
             merge_deployment.as_ref(),
-            options.kargs.unwrap_or_default(),
+            Some(&opts),
             cancellable,
         )?;
         let flags = ostree::SysrootSimpleWriteDeploymentFlags::NONE;


### PR DESCRIPTION
This is the same bug as
https://github.com/ostreedev/ostree-rs-ext/commit/3089166a4456cdcfa0568aedcda31eac65ac00ee but for the not-booted case.

Basically in the C API bridged to Rust we can't distinguish between "NULL array" and "zero length array".  But the _with_options path supports distinguishing them, and we want the "no kargs provided" case to not override anything.

Closes: https://github.com/ostreedev/ostree-rs-ext/issues/502