### PR TITLE
store: Tweak error message for non-ostree containers

### DIFF
--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -372,7 +372,7 @@ pub(crate) fn parse_manifest_layout<'a>(
 
     let (layout, target_diffid) = info.ok_or_else(|| {
         anyhow!(
-            "No {} label found, not an ostree-bootable container",
+            "No {} label found, not an ostree encapsulated container",
             ExportLayout::V1.label()
         )
     })?;


### PR DESCRIPTION
Since in theory we support non-bootable cases, and we actually have a distinct label for the bootable one.