### PR TITLE
lib: Dispatch to monomorphic function

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -818,7 +818,10 @@ where
     I: IntoIterator,
     I::Item: Into<OsString> + Clone,
 {
-    let opt = Opt::parse_from(args);
+    run_from_opt(Opt::parse_from(args)).await
+}
+
+async fn run_from_opt(opt: Opt) -> Result<()> {
     match opt {
         Opt::Tar(TarOpts::Import(ref opt)) => tar_import(opt).await,
         Opt::Tar(TarOpts::Export(ref opt)) => tar_export(opt),


### PR DESCRIPTION
I was looking at `cargo bloat` and this showed up near the top twice. It's a large function and only the option parsing needs to be generic.