### PR TITLE
Cargo.toml: Update `release` profile, add `releaselto`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,12 @@ opt-level = 1 # No optimizations are too slow for us.
 
 [profile.release]
 lto = "thin"
+# We use FFI so this is safest
+panic = "abort"
+# We assume we're being delivered via e.g. RPM which supports split debuginfo
+debug = true
+
+[profile.releaselto]
+codegen-units = 1
+inherits = "release"
+lto = "yes"


### PR DESCRIPTION
- `release` should use `panic=abort` by default because we make heavy use of FFI and this is safest, and I don't think we need unwinding anyways
- The `releaselto` produces smallest binaries