### PR TITLE
Cargo.toml: Set `resolver = 2`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           key: "build"
       - name: Build
-        run: cargo build --release
+        run: cargo build --release --features=internal-testing-api
       - name: Upload binary
         uses: actions/upload-artifact@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["cli", "lib"]
+resolver = "2"
 
 # These bits are copied from rpm-ostree.
 [profile.dev]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,3 +18,7 @@ tokio = { version = "1", features = ["macros"] }
 log = "0.4.0"
 tracing = "0.1"
 tracing-subscriber = "0.2.17"
+
+[features]
+# A proxy for the library feature
+internal-testing-api = ["ostree-ext/internal-testing-api"]


### PR DESCRIPTION


There's a warning in newer Rust 1.72 about this, we do want the v2
resolver.
