### PR TITLE
Bump rust-version = 1.70 && ci: Drop hard errors on clippy warnings by default

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,8 +15,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  # Pinned toolchain for linting
-  ACTION_LINTS_TOOLCHAIN: 1.70.0
 
 jobs:
   tests:
@@ -33,6 +31,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: "tests"
+      - name: cargo fmt (check)
+        run: cargo fmt -- --check -l
       - name: Build
         run: cargo test --no-run
       - name: Individual checks
@@ -41,6 +41,8 @@ jobs:
         run: cargo test -- --nocapture --quiet
       - name: Manpage generation
         run: mkdir -p target/man && cargo run --features=docgen -- man --directory target/man
+      # - name: cargo clippy
+      #   run: cargo clippy
   build:
     runs-on: ubuntu-latest
     container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
@@ -94,25 +96,6 @@ jobs:
       with:
         log-level: warn
         command: check bans sources licenses
-  linting:
-    name: "Lints, pinned toolchain"
-    runs-on: ubuntu-latest
-    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Install deps
-        run: ./ci/installdeps.sh
-      - name: Remove system Rust toolchain
-        run: dnf remove -y rust cargo
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env['ACTION_LINTS_TOOLCHAIN']  }}
-          components: rustfmt, clippy
-      - name: cargo fmt (check)
-        run: cargo fmt -- --check -l
-      - name: cargo clippy (warnings)
-        run: cargo clippy -- -D warnings
   integration:
     name: "Integration"
     needs: build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # Pinned toolchain for linting
-  ACTION_LINTS_TOOLCHAIN: 1.64.0
+  ACTION_LINTS_TOOLCHAIN: 1.70.0
 
 jobs:
   tests:

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
 readme = "README.md"
 publish = false
-rust-version = "1.64.0"
+rust-version = "1.70.0"
 
 [dependencies]
 anyhow = "1.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -7,7 +7,7 @@ name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
 version = "0.11.5"
-rust-version = "1.64.0"
+rust-version = "1.70.0"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Bump rust-version = 1.70

clap_builder now pulls it in, and we need to follow that train...

---

ci: Drop hard errors on clippy warnings by default

It's just too much churn for too little value.

---

