### PR TITLE
ci: Re-enable clippy, but nonblocking

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,8 +41,8 @@ jobs:
         run: cargo test -- --nocapture --quiet
       - name: Manpage generation
         run: mkdir -p target/man && cargo run --features=docgen -- man --directory target/man
-      # - name: cargo clippy
-      #   run: cargo clippy
+      - name: cargo clippy
+        run: cargo clippy
   build:
     runs-on: ubuntu-latest
     container: quay.io/coreos-assembler/fcos-buildroot:testing-devel


### PR DESCRIPTION
Blocking on clippy I think is just too painful for the value it provides.