### PR TITLE
sysroot: Add `from_assume_locked`

### DIFF
--- a/lib/src/sysroot.rs
+++ b/lib/src/sysroot.rs
@@ -9,10 +9,15 @@ use anyhow::Result;
 pub struct SysrootLock {
     /// The underlying sysroot value.
     pub sysroot: ostree::Sysroot,
+    /// True if we didn't actually lock
+    unowned: bool,
 }
 
 impl Drop for SysrootLock {
     fn drop(&mut self) {
+        if self.unowned {
+            return;
+        }
         self.sysroot.unlock();
     }
 }
@@ -28,12 +33,14 @@ impl Deref for SysrootLock {
 impl SysrootLock {
     /// Asynchronously acquire a sysroot lock.  If the lock cannot be acquired
     /// immediately, a status message will be printed to standard output.
+    /// The lock will be unlocked when this object is dropped.
     pub async fn new_from_sysroot(sysroot: &ostree::Sysroot) -> Result<Self> {
         let mut printed = false;
         loop {
             if sysroot.try_lock()? {
                 return Ok(Self {
                     sysroot: sysroot.clone(),
+                    unowned: false,
                 });
             }
             if !printed {
@@ -41,6 +48,15 @@ impl SysrootLock {
                 printed = true;
             }
             tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        }
+    }
+
+    /// This function should only be used when you have locked the sysroot
+    /// externally (e.g. in C/C++ code).  This also does not unlock on drop.
+    pub fn from_assumed_locked(sysroot: &ostree::Sysroot) -> Self {
+        Self {
+            sysroot: sysroot.clone(),
+            unowned: true,
         }
     }
 }


### PR DESCRIPTION
There's a mess with `SysrootLock` because in practice, way, way too many APIs just take the plain old C `Sysroot` object.

In this project, we added a new API that requires a `SysrootLock`, which works well when everything is using ostree-ext from the start, as it is in bootc.

However in rpm-ostree we acquire the lock from C code, but want to call `remove_undeployed_images` which wants `SysrootLock`.  The only practical way out of this is to add an API which asserts that the sysroot is locked and returns this wrapper.

What would actually work better here is to drive this locking logic down into the C library.