### PR TITLE
tar: Hold open input stream as long as possible

### DIFF
--- a/lib/src/container/unencapsulate.rs
+++ b/lib/src/container/unencapsulate.rs
@@ -165,6 +165,7 @@ pub(crate) async fn join_fetch<T: std::fmt::Debug>(
         (Err(worker), Err(driver)) => {
             let text = driver.root_cause().to_string();
             if text.ends_with("broken pipe") {
+                tracing::trace!("Ignoring broken pipe failure from driver");
                 Err(worker)
             } else {
                 Err(worker.context(format!("proxy failure: {} and client error", text)))


### PR DESCRIPTION
container: Add a trace log for when we discard "broken pipe" error

I don't think we're hitting this in https://github.com/coreos/rpm-ostree/issues/4567
but it'd be useful to have a trace message in case.

---

tar: Hold open input stream as long as possible

I'm hoping this will help us debug https://github.com/coreos/rpm-ostree/issues/4567
```
[2023-08-30T15:00:16.554Z] Aug 30 15:00:15 qemu0 kola-runext-container-image[1957]: error: Importing: Parsing layer blob sha256:00623c39da63781bdd3fb00fedb36f8b9ec95e42cdb4d389f692457f24c67144: Failed to invoke skopeo proxy method FinishPipe: remote error: write |1: broken pipe
```

I haven't been able to reproduce it outside of CI yet, but we had
a prior ugly hack for this in
https://github.com/ostreedev/ostree-rs-ext/commit/a27dac83831297a6e83bd25c5b6b1b842249ad4d

As the comments say - the goal is to hold open the input stream
as long as feasibly possible.

---

