### PR TITLE
Use cap_tempfile via cap_std_ext

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -20,7 +20,6 @@ olpc-cjson = "0.1.1"
 clap = { version= "4.2", features = ["derive"] }
 clap_mangen = { version = "0.2", optional = true }
 cap-std-ext = "2.0"
-cap-tempfile = "1.0"
 flate2 = { features = ["zlib"], default_features = false, version = "1.0.20" }
 fn-error-context = "0.2.0"
 futures-util = "0.3.13"

--- a/lib/src/bootabletree.rs
+++ b/lib/src/bootabletree.rs
@@ -91,7 +91,7 @@ pub fn find_kernel_dir_fs(root: &Dir) -> Result<Option<Utf8PathBuf>> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use cap_tempfile::cap_std;
+    use cap_std_ext::{cap_std, cap_tempfile};
 
     #[test]
     fn test_find_kernel_dir_fs() -> Result<()> {

--- a/lib/src/commit.rs
+++ b/lib/src/commit.rs
@@ -169,6 +169,7 @@ pub(crate) async fn container_commit() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cap_std_ext::cap_tempfile;
 
     #[test]
     fn commit() -> Result<()> {

--- a/lib/src/container/ocidir.rs
+++ b/lib/src/container/ocidir.rs
@@ -7,8 +7,8 @@
 use anyhow::{anyhow, Context, Result};
 use camino::Utf8Path;
 use cap_std::fs::Dir;
-use cap_std_ext::cap_std;
 use cap_std_ext::dirext::CapStdExtDirExt;
+use cap_std_ext::{cap_std, cap_tempfile};
 use containers_image_proxy::oci_spec;
 use flate2::write::GzEncoder;
 use fn_error_context::context;

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -841,7 +841,7 @@ impl ImageImporter {
                 let devino = ostree::RepoDevInoCache::new();
                 let repodir = repo.dfd_as_dir()?;
                 let repo_tmp = repodir.open_dir("tmp")?;
-                let td = cap_tempfile::TempDir::new_in(&repo_tmp)?;
+                let td = cap_std_ext::cap_tempfile::TempDir::new_in(&repo_tmp)?;
 
                 let rootpath = "root";
                 let checkout_mode = if repo.mode() == ostree::RepoMode::Bare {

--- a/lib/src/repair.rs
+++ b/lib/src/repair.rs
@@ -5,7 +5,7 @@ use std::fmt::Display;
 
 use anyhow::{anyhow, Context, Result};
 use cap_std::fs::Dir;
-use cap_tempfile::cap_std;
+use cap_std_ext::cap_std;
 use fn_error_context::context;
 use serde::{Deserialize, Serialize};
 use std::os::unix::fs::MetadataExt;

--- a/lib/src/tar/write.rs
+++ b/lib/src/tar/write.rs
@@ -12,8 +12,8 @@ use anyhow::{anyhow, Context};
 use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
 
 use cap_std::io_lifetimes;
-use cap_std_ext::cap_std;
 use cap_std_ext::cmdext::CapStdExtCommandExt;
+use cap_std_ext::{cap_std, cap_tempfile};
 use once_cell::unsync::OnceCell;
 use ostree::gio;
 use ostree::prelude::FileExt;


### PR DESCRIPTION
This way things like Dependabot understand there's only one dependency to bump instead of multiple that must move in lockstep.