### PR TITLE
lib: Bump to libsystemd 0.6

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -29,7 +29,7 @@ io-lifetimes = "1.0"
 indicatif = "0.17.0"
 once_cell = "1.9"
 libc = "0.2.92"
-libsystemd = "0.5.0"
+libsystemd = "0.6.0"
 openssl = "0.10.33"
 ostree = { features = ["v2022_5", "cap-std-apis"], version = "0.18.0" }
 pin-project = "1.0"


### PR DESCRIPTION
This updates to a more modern version which will help drop out e.g. `nix-0.23` from our dependency graph - it's long obsoleted.