### PR TITLE
chunking: Ignore ostree commit layer

### DIFF
--- a/lib/src/chunking.rs
+++ b/lib/src/chunking.rs
@@ -606,6 +606,10 @@ fn basic_packing_with_prior_build<'a>(
     for bin in curr_build {
         let mut mod_bin = Vec::new();
         for pkg in bin {
+            // An empty component set can happen for the ostree commit layer; ignore that.
+            if pkg.is_empty() {
+                continue;
+            }
             mod_bin.push(name_to_component[&pkg]);
         }
         modified_build.push(mod_bin);


### PR DESCRIPTION


I was hitting a panic in this section of the code; I think
triggering it involves removing packages, but I haven't narrowed
it down more precisely.

Hopefully at some point I will try to add some more unit
testing for this...

---

