### PR TITLE
lib: Bump to ostree 0.19, cap-std-ext 3.0 && lib: Bump to rustix 0.38 && Bump semver to 0.12

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -34,7 +34,7 @@ openssl = "0.10.33"
 ostree = { features = ["v2022_6"], version = "0.19.0" }
 pin-project = "1.0"
 regex = "1.5.4"
-rustix = { version = "0.37.19", features = ["fs", "process"] }
+rustix = { version = "0.38", features = ["fs", "process"] }
 serde = { features = ["derive"], version = "1.0.125" }
 serde_json = "1.0.64"
 tar = "0.4.38"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
-version = "0.11.6"
+version = "0.12.0"
 rust-version = "1.70.0"
 
 [dependencies]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -19,7 +19,7 @@ chrono = "0.4.19"
 olpc-cjson = "0.1.1"
 clap = { version= "4.2", features = ["derive"] }
 clap_mangen = { version = "0.2", optional = true }
-cap-std-ext = "2.0"
+cap-std-ext = "3.0"
 flate2 = { features = ["zlib"], default_features = false, version = "1.0.20" }
 fn-error-context = "0.2.0"
 futures-util = "0.3.13"
@@ -31,7 +31,7 @@ once_cell = "1.9"
 libc = "0.2.92"
 libsystemd = "0.6.0"
 openssl = "0.10.33"
-ostree = { features = ["v2022_5", "cap-std-apis"], version = "0.18.0" }
+ostree = { features = ["v2022_6"], version = "0.19.0" }
 pin-project = "1.0"
 regex = "1.5.4"
 rustix = { version = "0.37.19", features = ["fs", "process"] }

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -7,9 +7,11 @@
 
 use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
+use cap_std_ext::cap_std;
 use clap::{Parser, Subcommand};
 use fn_error_context::context;
-use ostree::{cap_std, gio, glib};
+use io_lifetimes::AsFd;
+use ostree::{gio, glib};
 use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::io::BufWriter;
@@ -38,7 +40,7 @@ pub fn parse_base_imgref(s: &str) -> Result<ImageReference> {
 pub fn parse_repo(s: &Utf8Path) -> Result<ostree::Repo> {
     let repofd = cap_std::fs::Dir::open_ambient_dir(s, cap_std::ambient_authority())
         .with_context(|| format!("Opening directory at '{s}'"))?;
-    ostree::Repo::open_at_dir(&repofd, ".")
+    ostree::Repo::open_at_dir(repofd.as_fd(), ".")
         .with_context(|| format!("Opening ostree repository at '{s}'"))
 }
 

--- a/lib/src/fixture.rs
+++ b/lib/src/fixture.rs
@@ -10,11 +10,12 @@ use crate::{gio, glib};
 use anyhow::{anyhow, Context, Result};
 use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
 use cap_std::fs::Dir;
+use cap_std_ext::cap_std;
 use cap_std_ext::prelude::CapStdExtCommandExt;
 use chrono::TimeZone;
 use fn_error_context::context;
+use io_lifetimes::AsFd;
 use once_cell::sync::Lazy;
-use ostree::cap_std;
 use regex::Regex;
 use std::borrow::Cow;
 use std::io::Write;
@@ -394,13 +395,21 @@ impl Fixture {
             .status()?;
         assert!(st.success());
 
-        let srcrepo =
-            ostree::Repo::create_at_dir(srcdir_dfd, "repo", ostree::RepoMode::Archive, None)
-                .context("Creating src/ repo")?;
+        let srcrepo = ostree::Repo::create_at_dir(
+            srcdir_dfd.as_fd(),
+            "repo",
+            ostree::RepoMode::Archive,
+            None,
+        )
+        .context("Creating src/ repo")?;
 
         dir.create_dir("dest")?;
-        let destrepo =
-            ostree::Repo::create_at_dir(&dir, "dest/repo", ostree::RepoMode::BareUser, None)?;
+        let destrepo = ostree::Repo::create_at_dir(
+            dir.as_fd(),
+            "dest/repo",
+            ostree::RepoMode::BareUser,
+            None,
+        )?;
         Ok(Self {
             tempdir,
             dir,

--- a/lib/src/keyfileext.rs
+++ b/lib/src/keyfileext.rs
@@ -9,12 +9,6 @@ pub trait KeyFileExt {
     fn optional_string(&self, group: &str, key: &str) -> Result<Option<GString>, glib::Error>;
     /// Get a boolean value, but return `None` if the key does not exist.
     fn optional_bool(&self, group: &str, key: &str) -> Result<Option<bool>, glib::Error>;
-    /// Get a string list value, but return `None` if the key does not exist.
-    fn optional_string_list(
-        &self,
-        group: &str,
-        key: &str,
-    ) -> Result<Option<Vec<GString>>, glib::Error>;
 }
 
 /// Consume a keyfile error, mapping the case where group or key is not found to `Ok(None)`.
@@ -42,14 +36,6 @@ impl KeyFileExt for glib::KeyFile {
     fn optional_bool(&self, group: &str, key: &str) -> Result<Option<bool>, glib::Error> {
         map_keyfile_optional(self.boolean(group, key))
     }
-
-    fn optional_string_list(
-        &self,
-        group: &str,
-        key: &str,
-    ) -> Result<Option<Vec<GString>>, glib::Error> {
-        map_keyfile_optional(self.string_list(group, key))
-    }
 }
 
 #[cfg(test)]
@@ -71,17 +57,5 @@ mod tests {
         assert_eq!(kf.optional_bool("foo", "bar").unwrap(), None);
         kf.set_boolean("foo", "somebool", false);
         assert_eq!(kf.optional_bool("foo", "somebool").unwrap(), Some(false));
-
-        assert_eq!(kf.optional_string_list("foo", "bar").unwrap(), None);
-        kf.set_string("foo", "somelist", "one;two;three");
-        assert_eq!(
-            kf.optional_string_list("foo", "somelist").unwrap(),
-            Some(
-                vec!["one", "two", "three"]
-                    .iter()
-                    .map(|&v| GString::from(v))
-                    .collect()
-            )
-        );
     }
 }

--- a/lib/src/repair.rs
+++ b/lib/src/repair.rs
@@ -90,7 +90,7 @@ impl InodeCheck {
 #[doc(hidden)]
 /// Detect if any commits are potentially incorrect due to inode truncations.
 pub fn check_inode_collision(repo: &ostree::Repo, verbose: bool) -> Result<InodeCheck> {
-    let repo_dir = repo.dfd_as_dir()?;
+    let repo_dir = Dir::reopen_dir(&repo.dfd_borrow())?;
     let objects = repo_dir.open_dir("objects")?;
 
     println!(

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -1,10 +1,10 @@
 use anyhow::{Context, Result};
 use camino::Utf8Path;
 use cap_std::fs::{Dir, DirBuilder};
+use cap_std_ext::cap_std;
 use containers_image_proxy::oci_spec;
 use containers_image_proxy::oci_spec::image::ImageManifest;
 use once_cell::sync::Lazy;
-use ostree::cap_std;
 use ostree_ext::chunking::ObjectMetaSized;
 use ostree_ext::container::{store, ManifestDiff};
 use ostree_ext::container::{


### PR DESCRIPTION
keyfileext: Drop optional_string_list

Nothing is using this, and the underlying glib type changed
so it's annoying to keep.

---

lib: Bump to ostree 0.19, cap-std-ext 3.0

This is just "keeping up with churn":

- Newer versions of glib crates
- Bump to cap-std-ext 0.3, which bumps cap-std 2.0

---

lib: Bump to rustix 0.38

Again just keeping up.

---

lib: Bump semver to 0.12

Because we bumped ostree.

---

