### PR TITLE
container: Move more metadata into `ExportOpts`

### DIFF
--- a/lib/src/chunking.rs
+++ b/lib/src/chunking.rs
@@ -269,7 +269,7 @@ impl Chunking {
     pub fn from_mapping(
         repo: &ostree::Repo,
         rev: &str,
-        meta: ObjectMetaSized,
+        meta: &ObjectMetaSized,
         max_layers: &Option<NonZeroU32>,
         prior_build_metadata: Option<&oci_spec::image::ImageManifest>,
     ) -> Result<Self> {
@@ -287,7 +287,7 @@ impl Chunking {
     #[allow(clippy::or_fun_call)]
     pub fn process_mapping(
         &mut self,
-        meta: ObjectMetaSized,
+        meta: &ObjectMetaSized,
         max_layers: &Option<NonZeroU32>,
         prior_build_metadata: Option<&oci_spec::image::ImageManifest>,
     ) -> Result<()> {

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -650,8 +650,7 @@ async fn container_export(
         skip_compression: compression_fast, // TODO rename this in the struct at the next semver break
         ..Default::default()
     };
-    let pushed =
-        crate::container::encapsulate(repo, rev, &config, None, Some(opts), None, imgref).await?;
+    let pushed = crate::container::encapsulate(repo, rev, &config, Some(opts), imgref).await?;
     println!("{}", pushed);
     Ok(())
 }

--- a/lib/src/fixture.rs
+++ b/lib/src/fixture.rs
@@ -679,15 +679,14 @@ impl Fixture {
             .context("Computing sizes")?;
         let opts = ExportOpts {
             max_layers: std::num::NonZeroU32::new(PKGS_V0_LEN as u32),
+            contentmeta: Some(&contentmeta),
             ..Default::default()
         };
         let digest = crate::container::encapsulate(
             self.srcrepo(),
             self.testref(),
             &config,
-            None,
             Some(opts),
-            Some(contentmeta),
             &imgref,
         )
         .await

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -457,13 +457,12 @@ async fn impl_test_container_import_export(chunked: bool) -> Result<()> {
     opts.copy_meta_keys = vec!["buildsys.checksum".to_string()];
     opts.copy_meta_opt_keys = vec!["nosuchvalue".to_string()];
     opts.max_layers = std::num::NonZeroU32::new(PKGS_V0_LEN as u32);
+    opts.contentmeta = contentmeta.as_ref();
     let digest = ostree_ext::container::encapsulate(
         fixture.srcrepo(),
         fixture.testref(),
         &config,
-        None,
         Some(opts),
-        contentmeta,
         &srcoci_imgref,
     )
     .await
@@ -514,8 +513,6 @@ async fn impl_test_container_import_export(chunked: bool) -> Result<()> {
             fixture.srcrepo(),
             fixture.testref(),
             &config,
-            None,
-            None,
             None,
             &ociarchive_dest,
         )
@@ -625,8 +622,6 @@ async fn test_unencapsulate_unbootable() -> Result<()> {
         fixture.srcrepo(),
         fixture.testref(),
         &config,
-        None,
-        None,
         None,
         &srcoci_imgref,
     )
@@ -961,8 +956,6 @@ async fn test_container_write_derive() -> Result<()> {
             cmd: Some(vec!["/bin/bash".to_string()]),
             ..Default::default()
         },
-        None,
-        None,
         None,
         &ImageReference {
             transport: Transport::OciDir,
@@ -1346,17 +1339,10 @@ async fn test_container_import_export_registry() -> Result<()> {
         cmd: Some(vec!["/bin/bash".to_string()]),
         ..Default::default()
     };
-    let digest = ostree_ext::container::encapsulate(
-        fixture.srcrepo(),
-        testref,
-        &config,
-        None,
-        None,
-        None,
-        &src_imgref,
-    )
-    .await
-    .context("exporting to registry")?;
+    let digest =
+        ostree_ext::container::encapsulate(fixture.srcrepo(), testref, &config, None, &src_imgref)
+            .await
+            .context("exporting to registry")?;
     let mut digested_imgref = src_imgref.clone();
     digested_imgref.name = format!("{}@{}", src_imgref.name, digest);
 


### PR DESCRIPTION
container: Move more metadata into `ExportOpts`

This drops two extra arguments we added over time; in
a few places before we had e.g. `None, None, None` being passed
which just looks awkward.  And we also threaded through all 3
in various places.

The `ExportOpts` just needs to grow a lifetime argument, but that
turned out to not be too bad when I realized we could use the
elided lifetime `<'_>` in all methods that use it.

---

container: Make `ExportOpts` `#[non_exhaustive]`

It's intended for this purpose, where we want to be able
to add elements to the struct over time without breaking semver.

---

