### PR TITLE
A story in which `#[non_exhaustive]` is discovered

### DIFF
--- a/lib/src/container/deploy.rs
+++ b/lib/src/container/deploy.rs
@@ -20,6 +20,7 @@ pub const STATEROOT_DEFAULT: &str = "default";
 
 /// Options configuring deployment.
 #[derive(Debug, Default)]
+#[non_exhaustive]
 pub struct DeployOpts<'a> {
     /// Kernel arguments to use.
     pub kargs: Option<&'a [&'a str]>,

--- a/lib/src/container/encapsulate.rs
+++ b/lib/src/container/encapsulate.rs
@@ -380,6 +380,7 @@ async fn build_impl(
 
 /// Options controlling commit export into OCI
 #[derive(Clone, Debug, Default)]
+#[non_exhaustive]
 pub struct ExportOpts {
     /// If true, do not perform gzip compression of the tar layers.
     pub skip_compression: bool,

--- a/lib/src/tar/import.rs
+++ b/lib/src/tar/import.rs
@@ -798,6 +798,7 @@ fn validate_sha256(input: String) -> Result<String> {
 
 /// Configuration for tar import.
 #[derive(Debug, Default)]
+#[non_exhaustive]
 pub struct TarImportOptions {
     /// Name of the remote to use for signature verification.
     pub remote: Option<String>,

--- a/lib/src/tar/write.rs
+++ b/lib/src/tar/write.rs
@@ -55,6 +55,7 @@ pub(crate) fn copy_entry(
 
 /// Configuration for tar layer commits.
 #[derive(Debug, Default)]
+#[non_exhaustive]
 pub struct WriteTarOptions {
     /// Base ostree commit hash
     pub base: Option<String>,

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -106,14 +106,9 @@ async fn test_tar_import_signed() -> Result<()> {
 
     // Verify we fail with an unknown remote.
     let src_tar = tokio::fs::File::from_std(fixture.dir.open(test_tar)?.into_std());
-    let r = ostree_ext::tar::import_tar(
-        fixture.destrepo(),
-        src_tar,
-        Some(TarImportOptions {
-            remote: Some("nosuchremote".to_string()),
-        }),
-    )
-    .await;
+    let mut taropts = TarImportOptions::default();
+    taropts.remote = Some("nosuchremote".to_string());
+    let r = ostree_ext::tar::import_tar(fixture.destrepo(), src_tar, Some(taropts)).await;
     assert_err_contains(r, r#"Remote "nosuchremote" not found"#);
 
     // Test a remote, but without a key
@@ -124,14 +119,9 @@ async fn test_tar_import_signed() -> Result<()> {
         .destrepo()
         .remote_add("myremote", None, Some(&opts.end()), gio::Cancellable::NONE)?;
     let src_tar = tokio::fs::File::from_std(fixture.dir.open(test_tar)?.into_std());
-    let r = ostree_ext::tar::import_tar(
-        fixture.destrepo(),
-        src_tar,
-        Some(TarImportOptions {
-            remote: Some("myremote".to_string()),
-        }),
-    )
-    .await;
+    let mut taropts = TarImportOptions::default();
+    taropts.remote = Some("myremote".to_string());
+    let r = ostree_ext::tar::import_tar(fixture.destrepo(), src_tar, Some(taropts)).await;
     assert_err_contains(r, r#"Can't check signature: public key not found"#);
 
     // And signed correctly
@@ -143,14 +133,9 @@ async fn test_tar_import_signed() -> Result<()> {
     .ignore_stdout()
     .run()?;
     let src_tar = tokio::fs::File::from_std(fixture.dir.open(test_tar)?.into_std());
-    let imported = ostree_ext::tar::import_tar(
-        fixture.destrepo(),
-        src_tar,
-        Some(TarImportOptions {
-            remote: Some("myremote".to_string()),
-        }),
-    )
-    .await?;
+    let mut taropts = TarImportOptions::default();
+    taropts.remote = Some("myremote".to_string());
+    let imported = ostree_ext::tar::import_tar(fixture.destrepo(), src_tar, Some(taropts)).await?;
     let (commitdata, state) = fixture.destrepo().load_commit(&imported)?;
     assert_eq!(
         CONTENTS_CHECKSUM_V0,
@@ -173,14 +158,9 @@ async fn test_tar_import_signed() -> Result<()> {
     })
     .await??;
     let src_tar = tokio::fs::File::from_std(fixture.dir.open(nometa)?.into_std());
-    let r = ostree_ext::tar::import_tar(
-        fixture.destrepo(),
-        src_tar,
-        Some(TarImportOptions {
-            remote: Some("myremote".to_string()),
-        }),
-    )
-    .await;
+    let mut taropts = TarImportOptions::default();
+    taropts.remote = Some("myremote".to_string());
+    let r = ostree_ext::tar::import_tar(fixture.destrepo(), src_tar, Some(taropts)).await;
     assert_err_contains(r, "Expected commitmeta object");
 
     // Now inject garbage into the commitmeta by flipping some bits in the signature
@@ -210,14 +190,9 @@ async fn test_tar_import_signed() -> Result<()> {
     })
     .await??;
     let src_tar = tokio::fs::File::from_std(fixture.dir.open(nometa)?.into_std());
-    let r = ostree_ext::tar::import_tar(
-        fixture.destrepo(),
-        src_tar,
-        Some(TarImportOptions {
-            remote: Some("myremote".to_string()),
-        }),
-    )
-    .await;
+    let mut taropts = TarImportOptions::default();
+    taropts.remote = Some("myremote".to_string());
+    let r = ostree_ext::tar::import_tar(fixture.destrepo(), src_tar, Some(taropts)).await;
     assert_err_contains(r, "BAD signature");
 
     Ok(())

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -453,12 +453,10 @@ async fn impl_test_container_import_export(chunked: bool) -> Result<()> {
             ObjectMetaSized::compute_sizes(fixture.srcrepo(), meta).context("Computing sizes")
         })
         .transpose()?;
-    let opts = ExportOpts {
-        copy_meta_keys: vec!["buildsys.checksum".to_string()],
-        copy_meta_opt_keys: vec!["nosuchvalue".to_string()],
-        max_layers: std::num::NonZeroU32::new(PKGS_V0_LEN as u32),
-        ..Default::default()
-    };
+    let mut opts = ExportOpts::default();
+    opts.copy_meta_keys = vec!["buildsys.checksum".to_string()];
+    opts.copy_meta_opt_keys = vec!["nosuchvalue".to_string()];
+    opts.max_layers = std::num::NonZeroU32::new(PKGS_V0_LEN as u32);
     let digest = ostree_ext::container::encapsulate(
         fixture.srcrepo(),
         fixture.testref(),


### PR DESCRIPTION
tar: Make `WriteTarOptions` `#[non_exhaustive]`

To allow future extensibility.

---

tar: Make `TarImportOptions` `#[non_exhaustive]`

To allow future extensibility.

---

container: Make `DeployOpts` `#[non_exhaustive]`

To allow future extensibility.

---

container: Make `ExportOpts` `#[non_exhaustive]`

To allow future extensibility.

---

