### PR TITLE
two minor patches

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -826,7 +826,7 @@ fn handle_serialize_to_file<T: serde::Serialize>(path: Option<&Utf8Path>, obj: T
 }
 
 /// Parse the provided arguments and execute.
-/// Calls [`structopt::clap::Error::exit`] on failure, printing the error message and aborting the program.
+/// Calls [`clap::Error::exit`] on failure, printing the error message and aborting the program.
 pub async fn run_from_iter<I>(args: I) -> Result<()>
 where
     I: IntoIterator,

--- a/lib/src/container/encapsulate.rs
+++ b/lib/src/container/encapsulate.rs
@@ -25,6 +25,7 @@ use tracing::instrument;
 /// The label which may be used in addition to the standard OCI label.
 pub const LEGACY_VERSION_LABEL: &str = "version";
 
+// semver-break: Delete this and only support v1
 /// Type of container image generated
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum ExportLayout {

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -1012,6 +1012,7 @@ pub fn query_image_commit(repo: &ostree::Repo, commit: &str) -> Result<Box<Layer
 ///
 /// This is a thin wrapper for [`query_image_ref`] and should
 /// be considered deprecated.
+// semver-break: Delete this and rename query_image_ref -> query_image
 pub fn query_image(
     repo: &ostree::Repo,
     imgref: &OstreeImageReference,
@@ -1030,6 +1031,7 @@ fn manifest_for_image(repo: &ostree::Repo, imgref: &ImageReference) -> Result<Im
 /// Copy a downloaded image from one repository to another.
 #[context("Copying image")]
 #[deprecated = "Use copy_as instead"]
+// semver-break: Delete this and rename copy_as -> copy
 pub async fn copy(
     src_repo: &ostree::Repo,
     dest_repo: &ostree::Repo,


### PR DESCRIPTION
lib: Add a few semver-break cookies

So we know what to change for the next semver break; all minor
cleanups.

---

cli: Fix a doc link

Just noticed this running `cargo doc --lib`.

---

