### PR TITLE
container: Add dir container deploy test 

### DIFF
--- a/ci/priv-integration.sh
+++ b/ci/priv-integration.sh
@@ -86,7 +86,9 @@ RUN touch /usr/share/somefile
 EOF
 systemd-run -dP --wait podman build -t localhost/fcos-derived .
 derived_img=oci:/var/tmp/derived.oci
+derived_img_dir=dir:/var/tmp/derived.dir
 systemd-run -dP --wait skopeo copy containers-storage:localhost/fcos-derived "${derived_img}"
+systemd-run -dP --wait skopeo copy "${derived_img}" "${derived_img_dir}"
 
 # Prune to reset state
 ostree refs ostree/container/image --delete
@@ -105,6 +107,12 @@ ostree-ext-cli container image deploy --sysroot "${sysroot}" \
 img_commit2=$(ostree --repo=${repo} rev-parse ostree/container/image/${imgref})
 test "${img_commit}" = "${img_commit2}"
 echo "ok deploy derived container identical revs"
+
+ostree-ext-cli container image deploy --sysroot "${sysroot}" \
+        --stateroot "${stateroot}" --imgref ostree-unverified-image:"${derived_img_dir}"
+echo "ok deploy derived container from local dir"
+ostree-ext-cli container image remove --repo "${repo}" "${derived_img_dir}"
+rm -rf /var/tmp/derived.dir
 
 # Verify policy
 


### PR DESCRIPTION
This change adds an integration test for deploying from a container image stored in a local directory. It is directly related a recent change to support the `dir:` transport when using `ostree container image deploy`: https://github.com/ostreedev/ostree-rs-ext/pull/544