### PR TITLE
lib/container: Add APIs to retrieve version conveniently

### DIFF
--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -140,6 +140,13 @@ impl LayeredImageState {
             self.base_commit.as_str()
         }
     }
+
+    /// Retrieve the container image version.
+    pub fn version(&self) -> Option<&str> {
+        self.configuration
+            .as_ref()
+            .and_then(super::version_for_config)
+    }
 }
 
 /// Locally cached metadata for an update to an existing image.
@@ -151,6 +158,13 @@ pub struct CachedImageUpdate {
     pub config: ImageConfiguration,
     /// The digest of the manifest
     pub manifest_digest: String,
+}
+
+impl CachedImageUpdate {
+    /// Retrieve the container image version.
+    pub fn version(&self) -> Option<&str> {
+        super::version_for_config(&self.config)
+    }
 }
 
 /// Context for importing a container image.

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -780,13 +780,15 @@ r usr/bin/bash bash-v0
     {
         let cached = store::query_image_ref(fixture.destrepo(), &imgref.imgref)
             .unwrap()
-            .unwrap()
-            .cached_update
             .unwrap();
+        assert_eq!(cached.version(), Some("42.0"));
+
+        let cached_update = cached.cached_update.unwrap();
         assert_eq!(
-            cached.manifest_digest.as_str(),
+            cached_update.manifest_digest.as_str(),
             prep.manifest_digest.as_str()
         );
+        assert_eq!(cached_update.version(), Some("42.0"));
     }
     let to_fetch = prep.layers_to_fetch().collect::<Result<Vec<_>>>()?;
     assert_eq!(to_fetch.len(), 2);


### PR DESCRIPTION
This also relates to https://github.com/containers/oci-spec-rs/pull/143

Basically getting the version from the config requires a helper, this is a lot more convenient.