### PR TITLE
Quiet extremely verbose tracing::debug

### DIFF
--- a/lib/src/container/encapsulate.rs
+++ b/lib/src/container/encapsulate.rs
@@ -317,7 +317,7 @@ pub(crate) fn parse_oci_path_and_tag(path: &str) -> (&str, Option<&str>) {
 }
 
 /// Helper for `build()` that avoids generics
-#[instrument(skip(repo, config, opts))]
+#[instrument(level = "debug", skip_all)]
 async fn build_impl(
     repo: &ostree::Repo,
     ostree_ref: &str,

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -1154,7 +1154,7 @@ pub fn query_image_commit(repo: &ostree::Repo, commit: &str) -> Result<Box<Layer
         configuration,
         cached_update,
     });
-    tracing::debug!(state = ?state);
+    tracing::debug!("Wrote merge commit {}", state.merge_commit);
     Ok(state)
 }
 

--- a/lib/src/container/unencapsulate.rs
+++ b/lib/src/container/unencapsulate.rs
@@ -178,7 +178,7 @@ pub(crate) async fn join_fetch<T: std::fmt::Debug>(
 
 /// Fetch a container image and import its embedded OSTree commit.
 #[context("Importing {}", imgref)]
-#[instrument(skip(repo))]
+#[instrument(level = "debug", skip(repo))]
 pub async fn unencapsulate(repo: &ostree::Repo, imgref: &OstreeImageReference) -> Result<Import> {
     let importer = super::store::ImageImporter::new(repo, imgref, Default::default()).await?;
     importer.unencapsulate().await
@@ -199,7 +199,6 @@ fn new_async_decompressor<'a>(
 }
 
 /// A wrapper for [`get_blob`] which fetches a layer and decompresses it.
-//#[instrument(skip(proxy, img, layer))]
 pub(crate) async fn fetch_layer_decompress<'a>(
     proxy: &'a mut ImageProxy,
     img: &OpenedImage,

--- a/lib/src/tar/import.rs
+++ b/lib/src/tar/import.rs
@@ -806,7 +806,7 @@ pub struct TarImportOptions {
 
 /// Read the contents of a tarball and import the ostree commit inside.
 /// Returns the sha256 of the imported commit.
-#[instrument(skip(repo, src))]
+#[instrument(level = "debug", skip_all)]
 pub async fn import_tar(
     repo: &ostree::Repo,
     src: impl tokio::io::AsyncRead + Send + Unpin + 'static,
@@ -831,7 +831,7 @@ pub async fn import_tar(
 
 /// Read the contents of a tarball and import the content objects inside.
 /// Generates a synthetic commit object referencing them.
-#[instrument(skip(repo, src))]
+#[instrument(level = "debug", skip_all)]
 pub async fn import_tar_objects(
     repo: &ostree::Repo,
     src: impl tokio::io::AsyncRead + Send + Unpin + 'static,

--- a/lib/src/tar/write.rs
+++ b/lib/src/tar/write.rs
@@ -286,7 +286,7 @@ async fn filter_tar_async(
 
 /// Write the contents of a tarball as an ostree commit.
 #[allow(unsafe_code)] // For raw fd bits
-#[instrument(skip(repo, src))]
+#[instrument(level = "debug", skip_all)]
 pub async fn write_tar(
     repo: &ostree::Repo,
     src: impl tokio::io::AsyncRead + Send + Unpin + 'static,


### PR DESCRIPTION
tree-wide: Clean up usage of `tracing::instrument`

We're really verbose with `env RUST_LOG=debug`...most of
these spans shouldn't be emitting any arguments at all . And
even then let's lower to debug level for them too.

---

store: Silence extremely verbose tracing::debug

This ends up recursing into the manifest/config objects
which is a wall of spam with `env RUST_LOG=debug`.  Just print
the merge commit to start here.

---

