### PR TITLE
deploy: Always use merge commit

### DIFF
--- a/lib/src/container/deploy.rs
+++ b/lib/src/container/deploy.rs
@@ -81,7 +81,7 @@ pub async fn deploy(
             imp.import(prep).await?
         }
     };
-    let commit = state.get_commit();
+    let commit = state.merge_commit.as_str();
     let origin = glib::KeyFile::new();
     let target_imgref = options.target_imgref.unwrap_or(imgref);
     origin.set_string("origin", ORIGIN_CONTAINER, &target_imgref.to_string());


### PR DESCRIPTION
I don't recall now the rationale for the previous code; if we're using this path we always want to be in a container-native mode.  Currently the "unpack to pure ostree commit" gets triggered if one uses this on a container image created via raw `ostree container encapsulate`.

Anyone who wants the prior behavior should instead unencapsulate and deploy the underlying commit.