### PR TITLE
tar: Fix multiple hardlinks

### DIFF
--- a/lib/src/tar/write.rs
+++ b/lib/src/tar/write.rs
@@ -223,12 +223,12 @@ pub(crate) fn filter_tar(
                     dest.append_data(&mut header, path, data)?;
                     // And cache this file path as the new link target
                     new_sysroot_link_targets.insert(target.to_owned(), path.to_owned());
-                } else if let Some(target) = new_sysroot_link_targets.get(path) {
-                    tracing::debug!("Relinking {path} to {target}");
+                } else if let Some(real_target) = new_sysroot_link_targets.get(target) {
+                    tracing::debug!("Relinking {path} to {real_target}");
                     // We found a 2nd (or 3rd, etc.) link into /sysroot; rewrite the link
                     // target to be the first file outside of /sysroot we found.
                     let mut header = header.clone();
-                    dest.append_link(&mut header, path, target)?;
+                    dest.append_link(&mut header, path, real_target)?;
                 } else {
                     tracing::debug!("Found unhandled modified link from {path} to {target}");
                 }


### PR DESCRIPTION
The previous commit here (43e1648e97ef82f2cb86fd0813a5f338585eea97) handled the case of *one* hardlink, but the logic for the secondary one was backwards.

I noticed this when generating a derived image, in some cases we only end up with `/usr/lib/sysimage/rpm-ostree-base-db` as modified, which causes really confusing semantics that look like packages going missing.