### PR TITLE
isolation: Also reset environment

### DIFF
--- a/lib/src/isolation.rs
+++ b/lib/src/isolation.rs
@@ -31,6 +31,7 @@ pub(crate) fn unprivileged_subprocess(binary: &str, user: &str) -> Command {
     cmd.args([
         "--no-new-privs",
         "--init-groups",
+        "--reset-env",
         "--reuid",
         user,
         "--bounding-set",


### PR DESCRIPTION
Otherwise in some cases the containers/image stack can try to look at things like `$HOME` which might be set to `/root` if we're running outside of systemd, and that can cause permission denials.