### PR TITLE
Support non-`/usr` content if ostree configured with overlayfs

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -842,7 +842,7 @@ async fn testing(opts: &TestingOpts) -> Result<()> {
         TestingOpts::Run => crate::integrationtest::run_tests(),
         TestingOpts::RunIMA => crate::integrationtest::test_ima(),
         TestingOpts::FilterTar => {
-            crate::tar::filter_tar(std::io::stdin(), std::io::stdout()).map(|_| {})
+            crate::tar::filter_tar(std::io::stdin(), std::io::stdout(), false).map(|_| {})
         }
     }
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -39,6 +39,7 @@ pub mod ima;
 pub mod keyfileext;
 pub(crate) mod logging;
 pub mod mountutil;
+pub mod ostree_prepareroot;
 pub mod refescape;
 #[doc(hidden)]
 pub mod repair;
@@ -54,6 +55,9 @@ pub mod objectsource;
 pub(crate) mod objgv;
 #[cfg(feature = "internal-testing-api")]
 pub mod ostree_manual;
+#[cfg(not(feature = "internal-testing-api"))]
+pub(crate) mod ostree_manual;
+
 pub(crate) mod statistics;
 
 mod utils;

--- a/lib/src/ostree_prepareroot.rs
+++ b/lib/src/ostree_prepareroot.rs
@@ -1,0 +1,57 @@
+//! Logic related to parsing ostree-prepare-root.conf.
+//!
+
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use anyhow::{Context, Result};
+use camino::Utf8Path;
+use glib::Cast;
+use ostree::prelude::FileExt;
+use ostree::{gio, glib};
+
+use crate::keyfileext::KeyFileExt;
+use crate::ostree_manual;
+
+pub(crate) const CONF_PATH: &str = "ostree/prepare-root.conf";
+
+pub(crate) fn load_config(root: &ostree::RepoFile) -> Result<Option<glib::KeyFile>> {
+    let cancellable = gio::Cancellable::NONE;
+    let kf = glib::KeyFile::new();
+    for path in ["etc", "usr/lib"].into_iter().map(Utf8Path::new) {
+        let path = &path.join(CONF_PATH);
+        let f = root.resolve_relative_path(&path);
+        if !f.query_exists(cancellable) {
+            continue;
+        }
+        let f = f.downcast_ref::<ostree::RepoFile>().unwrap();
+        let contents = ostree_manual::repo_file_read_to_string(f)?;
+        kf.load_from_data(&contents, glib::KeyFileFlags::NONE)
+            .with_context(|| format!("Parsing {path}"))?;
+        tracing::debug!("Loaded {path}");
+        return Ok(Some(kf));
+    }
+    tracing::debug!("No {CONF_PATH} found");
+    Ok(None)
+}
+
+/// Query whether the target root has the `root.transient` key
+/// which sets up a transient overlayfs.
+pub(crate) fn overlayfs_root_enabled(root: &ostree::RepoFile) -> Result<bool> {
+    if let Some(config) = load_config(root)? {
+        overlayfs_enabled_in_config(&config)
+    } else {
+        Ok(false)
+    }
+}
+
+/// Query whether the config uses an overlayfs model (composefs or plain overlayfs).
+pub fn overlayfs_enabled_in_config(config: &glib::KeyFile) -> Result<bool> {
+    let root_transient = config
+        .optional_bool("root", "transient")?
+        .unwrap_or_default();
+    let required_composefs = config
+        .optional_string("composefs", "enabled")?
+        .map(|s| s.as_str() == "yes")
+        .unwrap_or_default();
+    Ok(root_transient || required_composefs)
+}

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -377,7 +377,8 @@ async fn test_tar_write() -> Result<()> {
     let tmpvarlog = tmproot.open_dir("var/log")?;
     tmpvarlog.write("foo.log", "foolog")?;
     tmpvarlog.write("bar.log", "barlog")?;
-    tmproot.create_dir("boot")?;
+    tmproot.create_dir("run")?;
+    tmproot.write("run/somefile", "somestate")?;
     let tmptar = "testlayer.tar";
     cmd!(sh, "tar cf {tmptar} -C tmproot .").run()?;
     let src = fixture.dir.open(tmptar)?;
@@ -393,7 +394,7 @@ async fn test_tar_write() -> Result<()> {
     .run()?;
     assert_eq!(r.filtered.len(), 1);
     assert!(r.filtered.get("var").is_none());
-    assert_eq!(*r.filtered.get("boot").unwrap(), 1);
+    assert_eq!(*r.filtered.get("run").unwrap(), 2);
 
     Ok(())
 }


### PR DESCRIPTION
This pairs with https://github.com/ostreedev/ostree/pull/3114

Basically if ostree has an overlayfs (whether writable or a readonly composefs), we're safe to handle non-`/usr` content.

However, we still *always* drop content from the
"API filesystems" like `/run`, `/dev` etc.  Because really, no one should be adding stuff there.