### PR TITLE
Add convenient API/CLI to prune all content

### DIFF
--- a/ci/priv-integration.sh
+++ b/ci/priv-integration.sh
@@ -58,7 +58,7 @@ for img in "${image}"; do
     test "$(($initial_refs - 1))" = "$pruned_refs"
     ostree admin --sysroot="${sysroot}" undeploy 0
     # TODO: when we fold together ostree and ostree-ext, automatically prune layers
-    n_commits=$(find ${sysroot}/ostree/repo -name '*.commit')
+    n_commits=$(find ${sysroot}/ostree/repo -name '*.commit' | wc -l)
     test "${n_commits}" -gt 0
     # But right now this still doesn't prune *content*
     ostree-ext-cli container image prune-layers --repo="${sysroot}/ostree/repo"
@@ -69,8 +69,8 @@ for img in "${image}"; do
         exit 1
     fi
     # And this one should GC the objects too
-    ostree-ext-cli container image prune-images --full --repo="${sysroot}/ostree/repo" > out.txt
-    n_commits=$(find ${sysroot}/ostree/repo -name '*.commit')
+    ostree-ext-cli container image prune-images --full --sysroot="${sysroot}" > out.txt
+    n_commits=$(find ${sysroot}/ostree/repo -name '*.commit' | wc -l)
     test "${n_commits}" -eq 0
 done
 

--- a/lib/src/container/deploy.rs
+++ b/lib/src/container/deploy.rs
@@ -2,14 +2,15 @@
 
 use std::collections::HashSet;
 
+use anyhow::Result;
+use fn_error_context::context;
+use ostree::glib;
+
 use super::store::{gc_image_layers, LayeredImageState};
 use super::{ImageReference, OstreeImageReference};
 use crate::container::store::PrepareResult;
 use crate::keyfileext::KeyFileExt;
 use crate::sysroot::SysrootLock;
-use anyhow::Result;
-use fn_error_context::context;
-use ostree::glib;
 
 /// The key in the OSTree origin which holds a serialized [`super::OstreeImageReference`].
 pub const ORIGIN_CONTAINER: &str = "container-image-reference";

--- a/lib/src/container/deploy.rs
+++ b/lib/src/container/deploy.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashSet;
 
-use super::store::LayeredImageState;
+use super::store::{gc_image_layers, LayeredImageState};
 use super::{ImageReference, OstreeImageReference};
 use crate::container::store::PrepareResult;
 use crate::keyfileext::KeyFileExt;
@@ -173,4 +173,48 @@ pub fn remove_undeployed_images(sysroot: &SysrootLock) -> Result<Vec<ImageRefere
         }
     }
     Ok(removed)
+}
+
+/// The result of a prune operation
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Pruned {
+    /// The number of images that were pruned
+    pub n_images: u32,
+    /// The number of image layers that were pruned
+    pub n_layers: u32,
+    /// The number of OSTree objects that were pruned
+    pub n_objects_pruned: u32,
+    /// The total size of pruned objects
+    pub objsize: u64,
+}
+
+impl Pruned {
+    /// Whether this prune was a no-op (i.e. no images, layers or objects were pruned).
+    pub fn is_empty(&self) -> bool {
+        self.n_images == 0 && self.n_layers == 0 && self.n_objects_pruned == 0
+    }
+}
+
+/// This combines the functionality of [`remove_undeployed_images()`] with [`super::store::gc_image_layers()`].
+pub fn prune(sysroot: &SysrootLock) -> Result<Pruned> {
+    let repo = &sysroot.repo();
+    // Prune container images which are not deployed.
+    // SAFETY: There should never be more than u32 images
+    let n_images = remove_undeployed_images(sysroot)?.len().try_into().unwrap();
+    // Prune unreferenced layer branches.
+    let n_layers = gc_image_layers(repo)?;
+    // Prune the objects in the repo; the above just removed refs (branches).
+    let (_, n_objects_pruned, objsize) = repo.prune(
+        ostree::RepoPruneFlags::REFS_ONLY,
+        0,
+        ostree::gio::Cancellable::NONE,
+    )?;
+    // SAFETY: The number of pruned objects should never be negative
+    let n_objects_pruned = u32::try_from(n_objects_pruned).unwrap();
+    Ok(Pruned {
+        n_images,
+        n_layers,
+        n_objects_pruned,
+        objsize,
+    })
 }


### PR DESCRIPTION
Add convenient API/CLI to prune all content

This is kind of a usability regression from
https://github.com/ostreedev/ostree-rs-ext/pull/498/commits/979b93a24765ab129c6f1414388a9c7565fe3d80
"deploy: Add an API to prune undeployed images"

This new API and CLI make it convenient to prune the images,
the layers, *and* the underlying objects.

cc https://github.com/coreos/rpm-ostree/pull/4720

This API in particular is what bootc wants.  For rpm-ostree
we do still want to separate pruning refs from objects, because
rpm-ostree may have layered packages, and we only want to traverse
the ostree repo to prune objects once.

---

deploy: (style) Move external crates before internal

This is preferred style.

---

