### PR TITLE
lib: Fix omitted lifetime in associated consts

### DIFF
--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -113,11 +113,11 @@ impl TryFrom<&str> for Transport {
 }
 
 impl Transport {
-    const OCI_STR: &str = "oci";
-    const OCI_ARCHIVE_STR: &str = "oci-archive";
-    const CONTAINERS_STORAGE_STR: &str = "containers-storage";
-    const LOCAL_DIRECTORY_STR: &str = "dir";
-    const REGISTRY_STR: &str = "registry";
+    const OCI_STR: &'static str = "oci";
+    const OCI_ARCHIVE_STR: &'static str = "oci-archive";
+    const CONTAINERS_STORAGE_STR: &'static str = "containers-storage";
+    const LOCAL_DIRECTORY_STR: &'static str = "dir";
+    const REGISTRY_STR: &'static str = "registry";
 
     /// Retrieve an identifier that can then be re-parsed from [`Transport::try_from::<&str>`].
     pub fn serializable_name(&self) -> &'static str {

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -465,9 +465,9 @@ fn timestamp_of_manifest_or_config(
 
 impl ImageImporter {
     /// The metadata key used in ostree commit metadata to serialize
-    const CACHED_KEY_MANIFEST_DIGEST: &str = "ostree-ext.cached.manifest-digest";
-    const CACHED_KEY_MANIFEST: &str = "ostree-ext.cached.manifest";
-    const CACHED_KEY_CONFIG: &str = "ostree-ext.cached.config";
+    const CACHED_KEY_MANIFEST_DIGEST: &'static str = "ostree-ext.cached.manifest-digest";
+    const CACHED_KEY_MANIFEST: &'static str = "ostree-ext.cached.manifest";
+    const CACHED_KEY_CONFIG: &'static str = "ostree-ext.cached.config";
 
     /// Create a new importer.
     #[context("Creating importer")]


### PR DESCRIPTION
See the tracking issue https://github.com/rust-lang/rust/issues/115010

There's now a warning for this in newer Rust versions.