### PR TITLE
store: Remove deprecated `query_image`, rename replacement

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -772,7 +772,7 @@ fn print_column(s: &str, clen: u16, remaining: &mut terminal_size::Width) {
 
 /// Output the container image history
 async fn container_history(repo: &ostree::Repo, imgref: &ImageReference) -> Result<()> {
-    let img = crate::container::store::query_image_ref(repo, imgref)?
+    let img = crate::container::store::query_image(repo, imgref)?
         .ok_or_else(|| anyhow::anyhow!("No such image: {}", imgref))?;
     let columns = [("ID", 20u16), ("SIZE", 10), ("CREATED BY", 0)];
     let width = terminal_size::terminal_size()
@@ -969,7 +969,7 @@ async fn run_from_opt(opt: Opt) -> Result<()> {
                     config,
                 } => {
                     let repo = parse_repo(&repo)?;
-                    let image = crate::container::store::query_image_ref(&repo, &imgref)?
+                    let image = crate::container::store::query_image(&repo, &imgref)?
                         .ok_or_else(|| anyhow::anyhow!("No such image"))?;
                     let stdout = std::io::stdout().lock();
                     let mut stdout = std::io::BufWriter::new(stdout);

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -652,7 +652,7 @@ impl ImageImporter {
         // Query for previous stored state
 
         let (previous_state, previous_imageid) =
-            if let Some(previous_state) = try_query_image_ref(&self.repo, &self.imgref.imgref)? {
+            if let Some(previous_state) = try_query_image(&self.repo, &self.imgref.imgref)? {
                 // If the manifest digests match, we're done.
                 if previous_state.manifest_digest == manifest_digest {
                     return Ok(PrepareResult::AlreadyPresent(previous_state));
@@ -1054,7 +1054,7 @@ pub fn list_images(repo: &ostree::Repo) -> Result<Vec<String>> {
 
 /// Attempt to query metadata for a pulled image; if it is corrupted,
 /// the error is printed to stderr and None is returned.
-fn try_query_image_ref(
+fn try_query_image(
     repo: &ostree::Repo,
     imgref: &ImageReference,
 ) -> Result<Option<Box<LayeredImageState>>> {
@@ -1074,7 +1074,7 @@ fn try_query_image_ref(
 
 /// Query metadata for a pulled image.
 #[context("Querying image {imgref}")]
-pub fn query_image_ref(
+pub fn query_image(
     repo: &ostree::Repo,
     imgref: &ImageReference,
 ) -> Result<Option<Box<LayeredImageState>>> {
@@ -1170,18 +1170,6 @@ pub fn query_image_commit(repo: &ostree::Repo, commit: &str) -> Result<Box<Layer
     });
     tracing::debug!("Wrote merge commit {}", state.merge_commit);
     Ok(state)
-}
-
-/// Query metadata for a pulled image.
-///
-/// This is a thin wrapper for [`query_image_ref`] and should
-/// be considered deprecated.
-// semver-break: Delete this and rename query_image_ref -> query_image
-pub fn query_image(
-    repo: &ostree::Repo,
-    imgref: &OstreeImageReference,
-) -> Result<Option<Box<LayeredImageState>>> {
-    query_image_ref(repo, &imgref.imgref)
 }
 
 fn manifest_for_image(repo: &ostree::Repo, imgref: &ImageReference) -> Result<ImageManifest> {

--- a/lib/src/repair.rs
+++ b/lib/src/repair.rs
@@ -191,7 +191,7 @@ pub fn analyze_for_repair(sysroot: &SysrootLock, verbose: bool) -> Result<Repair
     let mut booted_is_likely_corrupted = false;
     let mut staged_is_likely_corrupted = false;
     for imgref in all_images {
-        if let Some(state) = container_store::query_image_ref(repo, &imgref)? {
+        if let Some(state) = container_store::query_image(repo, &imgref)? {
             if !container_store::verify_container_image(
                 sysroot,
                 &imgref,

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -709,7 +709,7 @@ async fn test_container_chunked() -> Result<()> {
 
     let mut imp =
         store::ImageImporter::new(fixture.destrepo(), &imgref, Default::default()).await?;
-    assert!(store::query_image_ref(fixture.destrepo(), &imgref.imgref)
+    assert!(store::query_image(fixture.destrepo(), &imgref.imgref)
         .unwrap()
         .is_none());
     let prep = match imp.prepare().await.context("Init prep derived")? {
@@ -784,7 +784,7 @@ r usr/bin/bash bash-v0
     };
     // Verify we also serialized the cached update
     {
-        let cached = store::query_image_ref(fixture.destrepo(), &imgref.imgref)
+        let cached = store::query_image(fixture.destrepo(), &imgref.imgref)
             .unwrap()
             .unwrap();
         assert_eq!(cached.version(), Some("42.0"));


### PR DESCRIPTION
Knocking one thing off the semver bump TODO.