### PR TITLE
store: Cleanup `copy` function

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -1054,7 +1054,7 @@ async fn run_from_opt(opt: Opt) -> Result<()> {
                     let src_repo = parse_repo(&src_repo)?;
                     let dest_repo = parse_repo(&dest_repo)?;
                     let imgref = &imgref.imgref;
-                    crate::container::store::copy_as(&src_repo, imgref, &dest_repo, imgref).await
+                    crate::container::store::copy(&src_repo, imgref, &dest_repo, imgref).await
                 }
                 ContainerImageOpts::ReplaceDetachedMetadata {
                     src,

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -1192,21 +1192,6 @@ fn manifest_for_image(repo: &ostree::Repo, imgref: &ImageReference) -> Result<Im
     Ok(manifest_data_from_commitmeta(commit_meta)?.0)
 }
 
-/// Copy a downloaded image from one repository to another.
-#[context("Copying image")]
-#[deprecated = "Use copy_as instead"]
-// semver-break: Delete this and rename copy_as -> copy
-pub async fn copy(
-    src_repo: &ostree::Repo,
-    dest_repo: &ostree::Repo,
-    imgref: &OstreeImageReference,
-) -> Result<()> {
-    // For historical reasons, this function takes an ostree refernece
-    // as input, but the storage only operaties on image references.
-    let imgref = &imgref.imgref;
-    copy_as(src_repo, imgref, dest_repo, imgref).await
-}
-
 /// Copy a downloaded image from one repository to another, while also
 /// optionally changing the image reference type.
 #[context("Copying image")]

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -1195,7 +1195,7 @@ fn manifest_for_image(repo: &ostree::Repo, imgref: &ImageReference) -> Result<Im
 /// Copy a downloaded image from one repository to another, while also
 /// optionally changing the image reference type.
 #[context("Copying image")]
-pub async fn copy_as(
+pub async fn copy(
     src_repo: &ostree::Repo,
     src_imgref: &ImageReference,
     dest_repo: &ostree::Repo,

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -1185,7 +1185,7 @@ async fn test_container_write_derive() -> Result<()> {
         gio::Cancellable::NONE,
     )?;
     #[allow(deprecated)]
-    store::copy_as(
+    store::copy(
         fixture.destrepo(),
         &derived_ref.imgref,
         &destrepo2,
@@ -1204,7 +1204,7 @@ async fn test_container_write_derive() -> Result<()> {
         transport: Transport::Registry,
         name: target_name.to_string(),
     };
-    store::copy_as(
+    store::copy(
         fixture.destrepo(),
         &derived_ref.imgref,
         &destrepo2,

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -1185,9 +1185,14 @@ async fn test_container_write_derive() -> Result<()> {
         gio::Cancellable::NONE,
     )?;
     #[allow(deprecated)]
-    store::copy(fixture.destrepo(), &destrepo2, &derived_ref)
-        .await
-        .context("Copying")?;
+    store::copy_as(
+        fixture.destrepo(),
+        &derived_ref.imgref,
+        &destrepo2,
+        &derived_ref.imgref,
+    )
+    .await
+    .context("Copying")?;
 
     let images = store::list_images(&destrepo2)?;
     assert_eq!(images.len(), 1);


### PR DESCRIPTION
store: Remove deprecated `copy` function

Part of semver break cleanups.

---

store: Rename `copy_as` -> `copy`

Now that the old one is removed.

---

