### PR TITLE
012 backports

### DIFF
--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -113,11 +113,11 @@ impl TryFrom<&str> for Transport {
 }
 
 impl Transport {
-    const OCI_STR: &str = "oci";
-    const OCI_ARCHIVE_STR: &str = "oci-archive";
-    const CONTAINERS_STORAGE_STR: &str = "containers-storage";
-    const LOCAL_DIRECTORY_STR: &str = "dir";
-    const REGISTRY_STR: &str = "registry";
+    const OCI_STR: &'static str = "oci";
+    const OCI_ARCHIVE_STR: &'static str = "oci-archive";
+    const CONTAINERS_STORAGE_STR: &'static str = "containers-storage";
+    const LOCAL_DIRECTORY_STR: &'static str = "dir";
+    const REGISTRY_STR: &'static str = "registry";
 
     /// Retrieve an identifier that can then be re-parsed from [`Transport::try_from::<&str>`].
     pub fn serializable_name(&self) -> &'static str {

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -465,9 +465,9 @@ fn timestamp_of_manifest_or_config(
 
 impl ImageImporter {
     /// The metadata key used in ostree commit metadata to serialize
-    const CACHED_KEY_MANIFEST_DIGEST: &str = "ostree-ext.cached.manifest-digest";
-    const CACHED_KEY_MANIFEST: &str = "ostree-ext.cached.manifest";
-    const CACHED_KEY_CONFIG: &str = "ostree-ext.cached.config";
+    const CACHED_KEY_MANIFEST_DIGEST: &'static str = "ostree-ext.cached.manifest-digest";
+    const CACHED_KEY_MANIFEST: &'static str = "ostree-ext.cached.manifest";
+    const CACHED_KEY_CONFIG: &'static str = "ostree-ext.cached.config";
 
     /// Create a new importer.
     #[context("Creating importer")]

--- a/lib/src/isolation.rs
+++ b/lib/src/isolation.rs
@@ -28,10 +28,14 @@ pub(crate) fn unprivileged_subprocess(binary: &str, user: &str) -> Command {
         return Command::new(binary);
     }
     let mut cmd = Command::new("setpriv");
+    // Clear some strategic environment variables that may cause the containers/image stack
+    // to look in the wrong places for things.
+    cmd.env_remove("HOME");
+    cmd.env_remove("XDG_DATA_DIR");
+    cmd.env_remove("USER");
     cmd.args([
         "--no-new-privs",
         "--init-groups",
-        "--reset-env",
         "--reuid",
         user,
         "--bounding-set",


### PR DESCRIPTION
@jmarrero (et all) - I have created https://github.com/ostreedev/ostree-rs-ext/tree/branch-0.12 so we can make a new release on the 0.12 series.

These two changes are on top of the last 0.12 and include one completely safe one and the desired bugfix.

isolation: Only drop a few strategic environment variables

Closes: https://github.com/ostreedev/ostree-rs-ext/issues/582
(cherry picked from commit 263cd73b9e4d08779e2504df13a67104ab3e020c)

---

lib: Fix omitted lifetime in associated consts

See the tracking issue https://github.com/rust-lang/rust/issues/115010

There's now a warning for this in newer Rust versions.

(cherry picked from commit 939135377069c973715a2ac2f01daada06284ed8)

---

