### PR TITLE
encapsulate: Fix regression with relative directories

### DIFF
--- a/lib/src/container/encapsulate.rs
+++ b/lib/src/container/encapsulate.rs
@@ -319,15 +319,16 @@ async fn build_impl(
         drop(ocidir);
 
         // Pass the temporary oci directory as the current working directory for the skopeo process
+        let target_fd = 3i32;
         let tempoci = ImageReference {
             transport: Transport::OciDir,
-            name: ".".into(),
+            name: format!("/proc/self/fd/{target_fd}"),
         };
         let digest = skopeo::copy(
             &tempoci,
             dest,
             authfile.as_deref(),
-            Some(tempdir.try_clone()?),
+            Some((std::sync::Arc::new(tempdir.try_clone()?.into()), target_fd)),
         )
         .await?;
         Some(digest)


### PR DESCRIPTION
https://github.com/ostreedev/ostree-rs-ext/pull/586/commits/b104a467e9ed06663194c3b60334a5246eb988fb broke the rpm-ostree test suite, which encapsulates to a *relative* file path and so us doing `chdir` broke it.

Switch to passing down the dirfd and using `/proc/self/fd`.

(Mutable global state in `chdir` is bad)