### PR TITLE
deploy: Don't enforce container sigpolicy by default, add `--enforce-container-sigpolicy`

### DIFF
--- a/ci/priv-integration.sh
+++ b/ci/priv-integration.sh
@@ -39,9 +39,18 @@ ostree-ext-cli container image remove --repo "${sysroot}/ostree/repo" registry:"
 ostree admin --sysroot="${sysroot}" undeploy 0
 # Now test the new syntax which has a nicer --image that defaults to registry.
 ostree-ext-cli container image deploy --transport registry --sysroot "${sysroot}" \
-    --stateroot "${stateroot}" --image "${image}" --no-signature-verification
+    --stateroot "${stateroot}" --image "${image}"
 ostree admin --sysroot="${sysroot}" status
 ostree admin --sysroot="${sysroot}" undeploy 0
+if ostree-ext-cli container image deploy --transport registry --sysroot "${sysroot}" \
+    --stateroot "${stateroot}" --image "${image}" --enforce-container-sigpolicy 2>err.txt; then
+    echo "Deployment with enforced verification succeeded unexpectedly" 1>&2
+    exit 1
+fi
+if ! grep -Ee 'insecureAcceptAnything.*refusing usage' err.txt; then
+    echo "unexpected error" 1>&2
+    cat err.txt
+fi
 # Now we should prune it
 ostree-ext-cli container image prune-images --sysroot "${sysroot}"
 ostree-ext-cli container image list --repo "${sysroot}/ostree/repo" > out.txt

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -358,9 +358,16 @@ pub(crate) enum ContainerImageOpts {
         #[clap(long)]
         transport: Option<String>,
 
-        /// Explicitly opt-out of requiring any form of signature verification.
-        #[clap(long)]
+        /// This option does nothing and is now deprecated.  Signature verification enforcement
+        /// proved to not be viable.
+        ///
+        /// If you want to still enforce it, use `--enforce-container-sigpolicy`.
+        #[clap(long, conflicts_with = "enforce_container_sigpolicy")]
         no_signature_verification: bool,
+
+        /// Require that the containers-storage stack
+        #[clap(long)]
+        enforce_container_sigpolicy: bool,
 
         /// Enable verification via an ostree remote
         #[clap(long)]
@@ -1070,7 +1077,8 @@ async fn run_from_opt(opt: Opt) -> Result<()> {
                     imgref,
                     image,
                     transport,
-                    no_signature_verification,
+                    mut no_signature_verification,
+                    enforce_container_sigpolicy,
                     ostree_remote,
                     target_imgref,
                     no_imgref,
@@ -1078,6 +1086,9 @@ async fn run_from_opt(opt: Opt) -> Result<()> {
                     proxyopts,
                     write_commitid_to,
                 } => {
+                    // As of recent releases, signature verification enforcement is
+                    // off by default, and must be explicitly enabled.
+                    no_signature_verification = !enforce_container_sigpolicy;
                     let sysroot = &if let Some(sysroot) = sysroot {
                         ostree::Sysroot::new(Some(&gio::File::for_path(&sysroot)))
                     } else {


### PR DESCRIPTION


This mirrors the change done in
https://github.com/containers/bootc/pull/230/commits/20d2d6cdc1bb2ddf7f8a6884ad83efaa708b4c65

Basically our attempts to enforce this didn't really work out.