### PR TITLE
ci: Add reverse dependency testing targeting bootc

### DIFF
--- a/.github/workflows/bootc.yml
+++ b/.github/workflows/bootc.yml
@@ -1,0 +1,65 @@
+name: bootc
+
+permissions:
+  actions: read
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch: {}
+
+jobs:
+  build-c9s:
+    runs-on: ubuntu-latest
+    container: quay.io/centos/centos:stream9
+    steps:
+      - run: dnf -y install git-core
+      - uses: actions/checkout@v3
+        with:
+          repository: containers/bootc
+          path: bootc
+      - uses: actions/checkout@v3
+        with:
+          path: ostree-rs-ext
+      - name: Patch bootc to use ostree-rs-ext
+        run: |
+          set -xeuo pipefail
+          cd bootc
+          cat >> Cargo.toml << 'EOF'
+          [patch.crates-io]
+          ostree-ext = { path = "../ostree-rs-ext/lib" }
+          EOF
+      - name: Install deps
+        run: ./bootc/ci/installdeps.sh
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: "build-bootc-c9s"
+          workspaces: bootc
+      - name: Build
+        run: cd bootc && make test-bin-archive
+      - name: Upload binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: bootc-c9s.tar.zst
+          path: bootc/target/bootc.tar.zst
+  privtest-alongside:
+    name: "Test install-alongside"
+    needs: build-c9s
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download
+        uses: actions/download-artifact@v3
+        with:
+          name: bootc-c9s.tar.zst
+      - name: Install
+        run: tar -xvf bootc.tar.zst
+      - name: Integration tests
+        run: |
+          set -xeuo pipefail
+          sudo podman run --rm -ti --privileged -v /:/target -v /var/lib/containers:/var/lib/containers -v ./usr/bin/bootc:/usr/bin/bootc --pid=host --security-opt label=disable \
+            quay.io/centos-bootc/centos-bootc-dev:stream9 bootc install to-filesystem \
+            --karg=foo=bar --disable-selinux --replace=alongside /target
+


### PR DESCRIPTION
Similar to https://github.com/ostreedev/ostree/pull/3152/commits/3623f0d80564f228d009df22fe32f97c848691c1 this patches bootc with this code, and runs a bootc install to get a bit more end-to-end testing.