### PR TITLE
tar: Generalize a TarImportConfig

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -849,7 +849,8 @@ async fn testing(opts: &TestingOpts) -> Result<()> {
         TestingOpts::Run => crate::integrationtest::run_tests(),
         TestingOpts::RunIMA => crate::integrationtest::test_ima(),
         TestingOpts::FilterTar => {
-            crate::tar::filter_tar(std::io::stdin(), std::io::stdout(), false).map(|_| {})
+            crate::tar::filter_tar(std::io::stdin(), std::io::stdout(), &Default::default())
+                .map(|_| {})
         }
     }
 }


### PR DESCRIPTION
I plan to add another variant of this behavior in the future, and having a proper structure is better than a single `bool`.