### PR TITLE
Bump MSRV to 1.74

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
 readme = "README.md"
 publish = false
-rust-version = "1.70.0"
+rust-version = "1.74.0"
 
 [dependencies]
 anyhow = "1.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -7,7 +7,7 @@ name = "ostree-ext"
 readme = "README.md"
 repository = "https://github.com/ostreedev/ostree-rs-ext"
 version = "0.13.1"
-rust-version = "1.70.0"
+rust-version = "1.74.0"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
We really really want the MSRV-aware resolver, because we're just getting dragged on this by clap-lex bumping, when we don't have any dependency on newer versions of that really.