### PR TITLE
store: If ostree >= 2024.3, retain content in `/var`

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -849,7 +849,8 @@ async fn testing(opts: &TestingOpts) -> Result<()> {
         TestingOpts::Run => crate::integrationtest::run_tests(),
         TestingOpts::RunIMA => crate::integrationtest::test_ima(),
         TestingOpts::FilterTar => {
-            crate::tar::filter_tar(std::io::stdin(), std::io::stdout(), false).map(|_| {})
+            crate::tar::filter_tar(std::io::stdin(), std::io::stdout(), &Default::default())
+                .map(|_| {})
         }
     }
 }

--- a/lib/src/fixture.rs
+++ b/lib/src/fixture.rs
@@ -439,6 +439,10 @@ impl Fixture {
     pub fn clear_destrepo(&self) -> Result<()> {
         self.destrepo()
             .set_ref_immediate(None, self.testref(), None, gio::Cancellable::NONE)?;
+        for (r, _) in self.destrepo().list_refs(None, gio::Cancellable::NONE)? {
+            self.destrepo()
+                .set_ref_immediate(None, &r, None, gio::Cancellable::NONE)?;
+        }
         self.destrepo()
             .prune(ostree::RepoPruneFlags::REFS_ONLY, 0, gio::Cancellable::NONE)?;
         Ok(())


### PR DESCRIPTION



This is intended to pair with https://github.com/ostreedev/ostree/pull/3166

If we detect a new enough ostree version, then by default don't remap
content in `/var`, assuming that ostree itself will handle it.

In order to unit test this (without depending on the ostree version
that happens to be on the host) add an API to the importer
which allows overriding the version.

---

