### PR TITLE
tar: Unconditionally use repo tmpdir

### DIFF
--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -849,8 +849,14 @@ async fn testing(opts: &TestingOpts) -> Result<()> {
         TestingOpts::Run => crate::integrationtest::run_tests(),
         TestingOpts::RunIMA => crate::integrationtest::test_ima(),
         TestingOpts::FilterTar => {
-            crate::tar::filter_tar(std::io::stdin(), std::io::stdout(), &Default::default())
-                .map(|_| {})
+            let tmpdir = cap_std_ext::cap_tempfile::TempDir::new(cap_std::ambient_authority())?;
+            crate::tar::filter_tar(
+                std::io::stdin(),
+                std::io::stdout(),
+                &Default::default(),
+                &tmpdir,
+            )
+            .map(|_| {})
         }
     }
 }


### PR DESCRIPTION
The tar code had some fancy logic to lazily allocate a temporary directory if it turned out we needed one, which only broke in the rare case we needed one in an obscure circumstance (a bwrap container in osbuild).

But we already always have a tmpdir allocated in the ostree repo, so switch the code to use that.