### PR TITLE
Support /usr/lib/ostree/auth.json

### DIFF
--- a/man/ostree-container-auth.md
+++ b/man/ostree-container-auth.md
@@ -9,7 +9,8 @@ The OSTree container stack uses the same file formats as **containers-auth(5)** 
 not the same locations.
 
 When running as uid 0 (root), the tooling uses `/etc/ostree/auth.json` first, then looks
-in `/run/ostree/auth.json`.  For any other uid, the file paths used are in `${XDG_RUNTIME_DIR}/ostree/auth.json`.
+in `/run/ostree/auth.json`, and finally checks `/usr/lib/ostree/auth.json`.
+For any other uid, the file paths used are in `${XDG_RUNTIME_DIR}/ostree/auth.json`.
 
 In the future, it is likely that a path that is supported for both "system podman"
 usage and ostree will be added.


### PR DESCRIPTION
This matches the general systemd design; we want to support these values being stored in `/usr` too where it can be "sealed" to the system and not locally mutable state.