### PR TITLE
wip: attempt to drop async_compression

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -12,7 +12,6 @@ rust-version = "1.74.0"
 [dependencies]
 anyhow = "1.0"
 containers-image-proxy = "0.5.5"
-async-compression = { version = "0.4", features = ["gzip", "tokio", "zstd"] }
 camino = "1.0.4"
 chrono = "0.4.19"
 olpc-cjson = "0.1.1"
@@ -43,6 +42,7 @@ tokio = { features = ["io-std", "time", "process", "rt", "net"], version = ">= 1
 tokio-util = { features = ["io-util"], version = "0.7" }
 tokio-stream = { features = ["sync"], version = "0.1.8" }
 tracing = "0.1"
+zstd = "0.13.1"
 
 indoc = { version = "2", optional = true }
 xshell = { version = "0.2", optional = true }

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -850,13 +850,9 @@ async fn testing(opts: &TestingOpts) -> Result<()> {
         TestingOpts::RunIMA => crate::integrationtest::test_ima(),
         TestingOpts::FilterTar => {
             let tmpdir = cap_std_ext::cap_tempfile::TempDir::new(cap_std::ambient_authority())?;
-            crate::tar::filter_tar(
-                std::io::stdin(),
-                std::io::stdout(),
-                &Default::default(),
-                &tmpdir,
-            )
-            .map(|_| {})
+            let stdin = std::io::stdin();
+            crate::tar::filter_tar(stdin, std::io::stdout(), &Default::default(), &tmpdir)
+                .map(|_| {})
         }
     }
 }


### PR DESCRIPTION
This would be a workaround for the async_compression bug in https://github.com/ostreedev/ostree-rs-ext/issues/608

- This changes the public API so we need a semver bump
- It's pretty risky anyways and we may be better off with spawning a helper thread instead of using async_compression