### PR TITLE
container: Drop async_compression + support zstd:chunked

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -12,7 +12,6 @@ rust-version = "1.74.0"
 [dependencies]
 anyhow = "1.0"
 containers-image-proxy = "0.5.5"
-async-compression = { version = "0.4", features = ["gzip", "tokio", "zstd"] }
 camino = "1.0.4"
 chrono = "0.4.19"
 olpc-cjson = "0.1.1"
@@ -43,6 +42,7 @@ tokio = { features = ["io-std", "time", "process", "rt", "net"], version = ">= 1
 tokio-util = { features = ["io-util"], version = "0.7" }
 tokio-stream = { features = ["sync"], version = "0.1.8" }
 tracing = "0.1"
+zstd = "0.13.1"
 
 indoc = { version = "2", optional = true }
 xshell = { version = "0.2", optional = true }

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -401,10 +401,11 @@ async fn test_tar_write() -> Result<()> {
 #[tokio::test]
 async fn test_tar_write_tar_layer() -> Result<()> {
     let fixture = Fixture::new_v1()?;
-    let uncompressed_tar = tokio::io::BufReader::new(
-        async_compression::tokio::bufread::GzipDecoder::new(EXAMPLE_TAR_LAYER),
-    );
-    ostree_ext::tar::write_tar(fixture.destrepo(), uncompressed_tar, "test", None).await?;
+    let mut v = Vec::new();
+    let mut dec = flate2::bufread::GzDecoder::new(std::io::Cursor::new(EXAMPLE_TAR_LAYER));
+    let _n = std::io::copy(&mut dec, &mut v)?;
+    let r = tokio::io::BufReader::new(std::io::Cursor::new(v));
+    ostree_ext::tar::write_tar(fixture.destrepo(), r, "test", None).await?;
     Ok(())
 }
 


### PR DESCRIPTION
This is basically just a workaround for https://github.com/Nullus157/async-compression/issues/271

However, in practice I think we may as well just use
a native blocking tokio thread here.

There's a lot of shenanigans going on though because
we're wrapping sync I/O with async and then back to sync
because the tar code we're using is still sync.

What would be a lot better is to move the compression to be
inline with the sync tar parsing, but that would require some
API changes and more code motion.

Closes: https://github.com/ostreedev/ostree-rs-ext/issues/608