### PR TITLE
Ensure SELinux label policy is applied when merging image layers

### DIFF
--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -973,6 +973,7 @@ impl ImageImporter {
                 let modifier =
                     ostree::RepoCommitModifier::new(ostree::RepoCommitModifierFlags::CONSUME, None);
                 modifier.set_devino_cache(&devino);
+                modifier.set_sepolicy_from_commit(&repo, &base_commit, cancellable)?;
 
                 let mt = ostree::MutableTree::new();
                 repo.write_dfd_to_mtree(


### PR DESCRIPTION
This has some bearing on #388.

When importing a container image via `ostree container image pull ...`, care is taken to maintain SELinux label policy when importing the layers, vis:

https://github.com/ostreedev/ostree-rs-ext/blob/9a4743a657ffe0435018d9720c6df80a486ca0f1/lib/src/container/store.rs#L869-L876

and then in `write_tar` itself:

https://github.com/ostreedev/ostree-rs-ext/blob/9a4743a657ffe0435018d9720c6df80a486ca0f1/lib/src/tar/write.rs#L335-L343

However when it comes time to merge these layers with the base commit, we fail to apply the SELinux policy of the base commit:

https://github.com/ostreedev/ostree-rs-ext/blob/9a4743a657ffe0435018d9720c6df80a486ca0f1/lib/src/container/store.rs#L973-L985

This change adds a call to `ostree::RepoCommitModifier::set_sepolicy_from_commit()` to ensure that the SELinux labelling is consistent with the base commit.