### PR TITLE
lib: use pkg-config feature for zstd

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -42,7 +42,7 @@ tokio = { features = ["io-std", "time", "process", "rt", "net"], version = ">= 1
 tokio-util = { features = ["io-util"], version = "0.7" }
 tokio-stream = { features = ["sync"], version = "0.1.8" }
 tracing = "0.1"
-zstd = "0.13.1"
+zstd = { version = "0.13.1", features = ["pkg-config"] }
 
 indoc = { version = "2", optional = true }
 xshell = { version = "0.2", optional = true }


### PR DESCRIPTION
I don't want to default to using vendored C sources.