### PR TITLE
lib: Re-export containers_image_proxy in full

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -16,6 +16,7 @@
 // Re-export our dependencies.  See https://gtk-rs.org/blog/2021/06/22/new-release.html
 // "Dependencies are re-exported".  Users will need e.g. `gio::File`, so this avoids
 // them needing to update matching versions.
+pub use containers_image_proxy;
 pub use containers_image_proxy::oci_spec;
 pub use ostree;
 pub use ostree::gio;


### PR DESCRIPTION
We currently expose a type from that, so we might as well just re-export the whole thing.

I want to do some stuff directly with containers in bootc.