### PR TITLE
cli: Bump to tracing-subscriber 0.3

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,7 +17,7 @@ libc = "0.2.92"
 tokio = { version = "1", features = ["macros"] }
 log = "0.4.0"
 tracing = "0.1"
-tracing-subscriber = "0.2.17"
+tracing-subscriber = "0.3"
 
 [features]
 # A proxy for the library feature


### PR DESCRIPTION
The 0.2 series has been dead since
https://github.com/tokio-rs/tracing/releases/tag/tracing-subscriber-0.3.0 It's long past time to update.