### PR TITLE
Make authfile API public

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -27,7 +27,7 @@ pub use ostree::gio::glib;
 type Result<T> = anyhow::Result<T>;
 
 // Import global functions.
-mod globals;
+pub mod globals;
 
 mod isolation;
 


### PR DESCRIPTION
Prep for having bootc directly read these as part of using podman for pulls.

While we're here:

- Use cap-std on general principle
- Change the usage to just honoring the file content directly instead of re-reading the file
- Add unit tests using that too
- Switch to using camino for paths