### PR TITLE
tests: two fixes

### DIFF
--- a/lib/src/fixture.rs
+++ b/lib/src/fixture.rs
@@ -170,7 +170,7 @@ m 0 0 1755
 d tmp
 "## };
 pub const CONTENTS_CHECKSUM_V0: &str =
-    "f8c5c1ad93339fd6e928aec7819de79ecec4ec8a4d0cb3565bb1d127fd7f56db";
+    "acc42fb5c796033f034941dc688643bf8beddfd9068d87165344d2b99906220a";
 // 1 for ostree commit, 2 for max frequency packages, 3 as empty layer
 pub const LAYERS_V0_LEN: usize = 3usize;
 pub const PKGS_V0_LEN: usize = 7usize;
@@ -229,8 +229,12 @@ impl SeLabel {
         }
     }
 
+    pub fn xattrs(&self) -> Vec<(&[u8], &[u8])> {
+        vec![(b"security.selinux\0", self.to_str().as_bytes())]
+    }
+
     pub fn new_xattrs(&self) -> glib::Variant {
-        vec![("security.selinux".as_bytes(), self.to_str().as_bytes())].to_variant()
+        self.xattrs().to_variant()
     }
 }
 

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -806,7 +806,7 @@ r usr/bin/bash bash-v0
     assert!(second.0.commit.is_none());
     assert_eq!(
         first.1,
-        "ostree export of commit cc1180f8431dc5bd69172d9a9ded36038dc9449f7c6c48e7686c894e483bfb8a"
+        "ostree export of commit fe4ba8bbd8f61a69ae53cde0dd53c637f26dfbc87717b2e71e061415d931361e"
     );
     assert_eq!(second.1, "8 components");
 


### PR DESCRIPTION
fixture: Add missing trailing NUL in security.selinux xattr

Because we were only doing bare-user checkouts in the test
suite (and not trying to physically materialize the xattrs)
and because ostree today doesn't validate xattrs, this
problem was silently ignored.  But I was looking at
changing the tests to do a checkout, and this caused confusing
failures.

Add the missing trailing `NUL`.  Also while we're here,
split the xattr function in two; one which returns the
Rust-native value and a wrapper which converts to GVariant.

This will be useful later.

---

tests: Add some error context

This helped me debug a recent problem.

---

