### PR TITLE
proxy: Fix logic error with auth_data switch

### DIFF
--- a/lib/src/container/mod.rs
+++ b/lib/src/container/mod.rs
@@ -427,10 +427,10 @@ pub fn merge_default_container_proxy_opts_with_isolation(
     if !auth_specified {
         let root = &Dir::open_ambient_dir("/", cap_std::ambient_authority())?;
         config.auth_data = crate::globals::get_global_authfile(root)?.map(|a| a.1);
-        // If there's no authfile, then force on anonymous pulls to ensure
+        // If there's no auth data, then force on anonymous pulls to ensure
         // that the container stack doesn't try to find it in the standard
         // container paths.
-        if config.authfile.is_none() {
+        if config.auth_data.is_none() {
             config.auth_anonymous = true;
         }
     }


### PR DESCRIPTION
The previous change switched to use `auth_data` directly instead of passing the file.  Update the logic just below which needs adjustment to continue to support authenticated pulls.