### PR TITLE
container: Add support for re-exporting a fetched container

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -53,6 +53,7 @@ zstd = { version = "0.13.1", features = ["pkg-config"] }
 
 indoc = { version = "2", optional = true }
 xshell = { version = "0.2", optional = true }
+similar-asserts = { version = "1.5.0", optional = true }
 
 [dev-dependencies]
 quickcheck = "1"
@@ -66,4 +67,4 @@ features = ["dox"]
 [features]
 docgen = ["clap_mangen"]
 dox = ["ostree/dox"]
-internal-testing-api = ["xshell", "indoc"]
+internal-testing-api = ["xshell", "indoc", "similar-asserts"]

--- a/lib/src/chunking.rs
+++ b/lib/src/chunking.rs
@@ -31,7 +31,7 @@ pub(crate) const MAX_CHUNKS: u32 = 64;
 const MIN_CHUNKED_LAYERS: u32 = 4;
 
 /// A convenient alias for a reference-counted, immutable string.
-type RcStr = Rc<str>;
+pub(crate) type RcStr = Rc<str>;
 /// Maps from a checksum to its size and file names (multiple in the case of
 /// hard links).
 pub(crate) type ChunkMapping = BTreeMap<RcStr, (u64, Vec<Utf8PathBuf>)>;
@@ -215,7 +215,7 @@ impl Chunk {
         }
     }
 
-    fn move_obj(&mut self, dest: &mut Self, checksum: &str) -> bool {
+    pub(crate) fn move_obj(&mut self, dest: &mut Self, checksum: &str) -> bool {
         // In most cases, we expect the object to exist in the source.  However, it's
         // conveneient here to simply ignore objects which were already moved into
         // a chunk.

--- a/lib/src/chunking.rs
+++ b/lib/src/chunking.rs
@@ -30,7 +30,10 @@ pub(crate) const MAX_CHUNKS: u32 = 64;
 /// we will just drop down to one.
 const MIN_CHUNKED_LAYERS: u32 = 4;
 
+/// A convenient alias for a reference-counted, immutable string.
 type RcStr = Rc<str>;
+/// Maps from a checksum to its size and file names (multiple in the case of
+/// hard links).
 pub(crate) type ChunkMapping = BTreeMap<RcStr, (u64, Vec<Utf8PathBuf>)>;
 // TODO type PackageSet = HashSet<RcStr>;
 

--- a/lib/src/container/encapsulate.rs
+++ b/lib/src/container/encapsulate.rs
@@ -102,7 +102,7 @@ fn export_chunks(
 /// Write an ostree commit to an OCI blob
 #[context("Writing ostree root to blob")]
 #[allow(clippy::too_many_arguments)]
-fn export_chunked(
+pub(crate) fn export_chunked(
     repo: &ostree::Repo,
     commit: &str,
     ociw: &mut OciDir,


### PR DESCRIPTION
chunking: Add some doc comments

Just a drive by.

---

container: Add support for re-exporting a fetched container

The status quo today is basically that with a "pure ostree"
container image, one can pull it, and one *can* re-export
it with `ostree container encapsulate`...but doing so
loses *all chunking* i.e. you end up with a single
giant layer again.

Further, we don't support exporting derived images at all.

Fix both of these with a new CLI and API, for example:

```
$ ostree container image export --repo=/path/to/repo registry:quay.io/exampleos/someos:latest containers-storage:localhost/exampleos
```

Now...before one gets too excited, this is still suboptimal
in a bunch of ways:

- Copying to `containers-storage` is super inefficient, we indirect
  through a local `oci` directory because of the lack of "push"
  support in containers-image-proxy, *and* we end up with a full
  physical copy of the files even when we *could* reflink;
  cc https://github.com/containers/storage/issues/1849
- Because we don't currently save tar-split data, the use
  case of pushing to a registry is virtually guaranteed to produce
  changed diffids, and we'll hence end up duplicating layers
  on the registry

Now what is more interesting is that this code is going to help
us a bit for the use case of "recommitting" a derived container
image.

Signed-off-by: Colin Walters <walters@verbum.org>

---

