### PR TITLE
export: Add progress flag

### DIFF
--- a/lib/src/container/encapsulate.rs
+++ b/lib/src/container/encapsulate.rs
@@ -330,6 +330,7 @@ async fn build_impl(
             dest,
             authfile.as_deref(),
             Some((std::sync::Arc::new(tempdir.try_clone()?.into()), target_fd)),
+            false,
         )
         .await?;
         Some(digest)

--- a/lib/src/container/skopeo.rs
+++ b/lib/src/container/skopeo.rs
@@ -67,10 +67,14 @@ pub(crate) async fn copy(
     dest: &ImageReference,
     authfile: Option<&Path>,
     add_fd: Option<(std::sync::Arc<OwnedFd>, i32)>,
+    progress: bool,
 ) -> Result<String> {
     let digestfile = tempfile::NamedTempFile::new()?;
     let mut cmd = new_cmd();
-    cmd.stdout(std::process::Stdio::null()).arg("copy");
+    cmd.arg("copy");
+    if !progress {
+        cmd.stdout(std::process::Stdio::null());
+    }
     cmd.arg("--digestfile");
     cmd.arg(digestfile.path());
     if let Some((add_fd, n)) = add_fd {

--- a/lib/src/container/update_detachedmeta.rs
+++ b/lib/src/container/update_detachedmeta.rs
@@ -29,7 +29,7 @@ pub async fn update_detached_metadata(
     };
 
     // Full copy of the source image
-    let pulled_digest: String = skopeo::copy(src, &tempsrc_ref, None, None)
+    let pulled_digest: String = skopeo::copy(src, &tempsrc_ref, None, None, false)
         .await
         .context("Creating temporary copy to OCI dir")?;
 
@@ -124,7 +124,7 @@ pub async fn update_detached_metadata(
 
     // Finally, copy the mutated image back to the target.  For chunked images,
     // because we only changed one layer, skopeo should know not to re-upload shared blobs.
-    crate::container::skopeo::copy(&tempsrc_ref, dest, None, None)
+    crate::container::skopeo::copy(&tempsrc_ref, dest, None, None, false)
         .await
         .context("Copying to destination")
 }


### PR DESCRIPTION
This is a very slow operation and it'd be really
nice to have progress.

Unfortunately we don't have a sane way to propagate status from `skopeo copy`, so add an option to just output to stdout, which is usable now in bootc.