### PR TITLE
container: Drop unnecessary &mut

### DIFF
--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -705,7 +705,7 @@ impl ImageImporter {
                     .await?;
             }
             let (blob, driver) = fetch_layer_decompress(
-                &mut self.proxy,
+                &self.proxy,
                 &self.proxy_img,
                 &import.manifest,
                 &layer.layer,

--- a/lib/src/container/unencapsulate.rs
+++ b/lib/src/container/unencapsulate.rs
@@ -263,7 +263,7 @@ fn new_async_decompressor(
 
 /// A wrapper for [`get_blob`] which fetches a layer and decompresses it.
 pub(crate) async fn fetch_layer_decompress<'a>(
-    proxy: &'a mut ImageProxy,
+    proxy: &'a ImageProxy,
     img: &OpenedImage,
     manifest: &oci_image::ImageManifest,
     layer: &'a oci_image::Descriptor,


### PR DESCRIPTION
The proxy uses shared references; prep for some
investigation of parallel unpack.