### PR TITLE
config: Fix absolute symlinks

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -24,7 +24,7 @@ chrono = "0.4.19"
 olpc-cjson = "0.1.1"
 clap = { version= "4.2", features = ["derive"] }
 clap_mangen = { version = "0.2", optional = true }
-cap-std-ext = "4.0"
+cap-std-ext = "4.0.2"
 flate2 = { features = ["zlib"], default-features = false, version = "1.0.20" }
 fn-error-context = "0.2.0"
 futures-util = "0.3.13"


### PR DESCRIPTION
Use the API from https://github.com/coreos/cap-std-ext/pull/54 to fix absolute symlinks for `/etc/ostree/auth.json`.

cc https://github.com/containers/bootc/issues/679