### PR TITLE
clippy: Fix all the things

### DIFF
--- a/lib/src/chunking.rs
+++ b/lib/src/chunking.rs
@@ -428,6 +428,7 @@ fn packing_size(packing: &[Vec<&ObjectSourceMetaSized>]) -> u64 {
 /// - Mean and Standard Deviation Method
 ///      The medium partition from the previous step is less aggressively
 ///      classified by using mean for both size and frequency
+///
 /// Note: Assumes components is sorted by descending size
 fn get_partitions_with_threshold<'a>(
     components: &[&'a ObjectSourceMetaSized],

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -783,7 +783,7 @@ async fn container_export(
             map: raw
                 .mapping
                 .into_iter()
-                .map(|(k, v)| (k.into(), v.into()))
+                .map(|(k, v)| (k, v.into()))
                 .collect(),
             sizes: raw
                 .layers
@@ -793,7 +793,7 @@ async fn container_export(
                         identifier: k.clone().into(),
                         name: v.into(),
                         srcid: k.clone().into(),
-                        change_frequency: if k == "unpackaged" { std::u32::MAX } else { 1 },
+                        change_frequency: if k == "unpackaged" { u32::MAX } else { 1 },
                         change_time_offset: 1,
                     },
                     size: 1,
@@ -936,7 +936,7 @@ async fn container_history(repo: &ostree::Repo, imgref: &ImageReference) -> Resu
 
         let digest = layer.digest().as_str();
         // Verify it's OK to slice, this should all be ASCII
-        assert!(digest.chars().all(|c| c.is_ascii()));
+        assert!(digest.is_ascii());
         let digest_max = columns[0].1;
         let digest = &digest[0..digest_max as usize];
         print_column(digest, digest_max, &mut remaining);

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -757,7 +757,7 @@ impl ImageImporter {
                 .await?;
             }
             let (blob, driver) = fetch_layer_decompress(
-                &mut self.proxy,
+                &self.proxy,
                 &self.proxy_img,
                 &import.manifest,
                 &import.ostree_commit_layer.layer,
@@ -839,7 +839,7 @@ impl ImageImporter {
         // there to label all following layers.
         self.unencapsulate_base(&mut import, true).await?;
         let des_layers = self.proxy.get_layer_info(&self.proxy_img).await?;
-        let mut proxy = self.proxy;
+        let proxy = self.proxy;
         let proxy_img = self.proxy_img;
         let target_imgref = self.target_imgref.as_ref().unwrap_or(&self.imgref);
         let base_commit = import.ostree_commit_layer.commit.clone().unwrap();
@@ -868,7 +868,7 @@ impl ImageImporter {
                         .await?;
                 }
                 let (blob, driver) = super::unencapsulate::fetch_layer_decompress(
-                    &mut proxy,
+                    &proxy,
                     &proxy_img,
                     &import.manifest,
                     &layer.layer,
@@ -984,7 +984,7 @@ impl ImageImporter {
                 let modifier =
                     ostree::RepoCommitModifier::new(ostree::RepoCommitModifierFlags::CONSUME, None);
                 modifier.set_devino_cache(&devino);
-                modifier.set_sepolicy_from_commit(&repo, &base_commit, cancellable)?;
+                modifier.set_sepolicy_from_commit(repo, &base_commit, cancellable)?;
 
                 let mt = ostree::MutableTree::new();
                 repo.write_dfd_to_mtree(
@@ -1243,7 +1243,7 @@ fn chunking_from_layer_committed(
 ) -> Result<()> {
     let mut chunk = Chunk::default();
     let layer_ref = &ref_for_layer(l)?;
-    let root = repo.read_commit(&layer_ref, gio::Cancellable::NONE)?.0;
+    let root = repo.read_commit(layer_ref, gio::Cancellable::NONE)?.0;
     let e = root.enumerate_children(
         "standard::name,standard::size",
         gio::FileQueryInfoFlags::NOFOLLOW_SYMLINKS,
@@ -1288,7 +1288,7 @@ pub(crate) fn export_to_oci(
     let mut new_config = srcinfo.configuration.clone();
     new_config.history_mut().clear();
 
-    let mut dest_oci = ocidir::OciDir::ensure(&dest_oci)?;
+    let mut dest_oci = ocidir::OciDir::ensure(dest_oci)?;
 
     let opts = ExportOpts {
         skip_compression: opts.skip_compression,

--- a/lib/src/tar/write.rs
+++ b/lib/src/tar/write.rs
@@ -54,7 +54,7 @@ pub(crate) fn copy_entry(
             let target = entry.link_name()?.ok_or_else(|| anyhow!("Invalid link"))?;
             // Sanity check UTF-8 here too.
             let target: &Utf8Path = (&*target).try_into()?;
-            dest.append_link(&mut header, path, &*target)
+            dest.append_link(&mut header, path, target)
         }
         tar::EntryType::Link => {
             let target = entry.link_name()?.ok_or_else(|| anyhow!("Invalid link"))?;
@@ -395,7 +395,7 @@ pub async fn write_tar(
             c.arg("--selinux-policy");
             c.arg(sepolicy.path());
         }
-        c.arg(&format!(
+        c.arg(format!(
             "--add-metadata-string=ostree.importer.version={}",
             env!("CARGO_PKG_VERSION")
         ));


### PR DESCRIPTION
Mostly so when I subsequently update to use ocidir 0.3.0, I'll have a
clean slate so anything that shows up I know the update broke it.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
