### PR TITLE
Fix digest usage

### DIFF
--- a/lib/src/container/unencapsulate.rs
+++ b/lib/src/container/unencapsulate.rs
@@ -37,7 +37,7 @@ use super::*;
 use containers_image_proxy::{ImageProxy, OpenedImage};
 use fn_error_context::context;
 use futures_util::{Future, FutureExt, TryFutureExt as _};
-use oci_spec::image as oci_image;
+use oci_spec::image::{self as oci_image, Digest};
 use std::sync::{Arc, Mutex};
 use tokio::{
     io::{AsyncBufRead, AsyncRead},
@@ -140,7 +140,7 @@ pub struct Import {
     /// The ostree commit that was imported
     pub ostree_commit: String,
     /// The image digest retrieved
-    pub image_digest: String,
+    pub image_digest: Digest,
 
     /// Any deprecation warning
     pub deprecated_warning: Option<String>,

--- a/lib/src/container/update_detachedmeta.rs
+++ b/lib/src/container/update_detachedmeta.rs
@@ -55,7 +55,7 @@ pub async fn update_detached_metadata(
             .read_json_blob(manifest_descriptor)
             .context("Reading manifest json blob")?;
 
-        anyhow::ensure!(manifest_descriptor.digest().digest() == pulled_digest.digest());
+        anyhow::ensure!(manifest_descriptor.digest() == &pulled_digest);
         let platform = manifest_descriptor
             .platform()
             .as_ref()


### PR DESCRIPTION
In some places we started doing `.digest().digest()` which drops the algorithm. Some basic unit tests
would have caught this - I added one. We also need an "upgrade from previous" test.

Trying to fix this revealed a bunch more places where we had `String` and not `Digest`.

Fixing those gets us type safety and points out the problem areas.  Since we're breaking API as this will be the real first 0.15 release,

- Drop unnecessary ManifestLayerState wrappering
- Fix the manifest digest members of various structs to be a Digest