### PR TITLE
store: Only close self-pipe when we're done

### DIFF
--- a/lib/src/container/unencapsulate.rs
+++ b/lib/src/container/unencapsulate.rs
@@ -162,7 +162,7 @@ pub struct Import {
 /// to see if the worker function had an error *and* if the proxy
 /// had an error, but if the proxy's error ends in `broken pipe`
 /// then it means the real only error is from the worker.
-pub(crate) async fn join_fetch<T: std::fmt::Debug>(
+pub(crate) async fn join_fetch<T>(
     worker: impl Future<Output = Result<T>>,
     driver: impl Future<Output = Result<()>>,
 ) -> Result<T> {


### PR DESCRIPTION
This took a crazy long time to debug but after lots of false starts I think this is right. Basically what's going on is we have async tasks that are talking over a `pipe()` inside our own process.

We must not close the read side of the pipe until the writer is done.

I believe this is dependent on tokio task scheduling order, and it's way easier to reproduce when pinned to a single CPU.

Closes: https://github.com/ostreedev/ostree-rs-ext/issues/657