### PR TITLE
Import generic prep

### DIFF
--- a/lib/src/container/encapsulate.rs
+++ b/lib/src/container/encapsulate.rs
@@ -27,6 +27,8 @@ pub const LEGACY_VERSION_LABEL: &str = "version";
 /// The label which indicates where the ostree layers stop, and the
 /// derived ones start.
 pub const DIFFID_LABEL: &str = "ostree.final-diffid";
+/// The label for bootc.
+pub const BOOTC_LABEL: &str = "containers.bootc";
 
 /// Annotation injected into the layer to say that this is an ostree commit.
 /// However, because this gets lost when converted to D2S2 https://docs.docker.com/registry/spec/manifest-v2-2/
@@ -68,7 +70,7 @@ fn commit_meta_to_labels<'a>(
     #[allow(clippy::explicit_auto_deref)]
     if let Some(v) = meta.lookup::<bool>(*ostree::METADATA_KEY_BOOTABLE)? {
         labels.insert(ostree::METADATA_KEY_BOOTABLE.to_string(), v.to_string());
-        labels.insert("containers.bootc".into(), "1".into());
+        labels.insert(BOOTC_LABEL.into(), "1".into());
     }
     // Handle any other string-typed values here.
     for k in &[&ostree::METADATA_KEY_LINUX] {

--- a/lib/src/container/store.rs
+++ b/lib/src/container/store.rs
@@ -584,7 +584,9 @@ impl ImageImporter {
         let config_labels = super::labels_of(&config);
         if self.require_bootable {
             let bootable_key = *ostree::METADATA_KEY_BOOTABLE;
-            let bootable = config_labels.map_or(false, |l| l.contains_key(bootable_key));
+            let bootable = config_labels.map_or(false, |l| {
+                l.contains_key(bootable_key) || l.contains_key(BOOTC_LABEL)
+            });
             if !bootable {
                 anyhow::bail!("Target image does not have {bootable_key} label");
             }

--- a/lib/tests/it/main.rs
+++ b/lib/tests/it/main.rs
@@ -395,7 +395,9 @@ async fn test_tar_write() -> Result<()> {
     .run()?;
     assert_eq!(r.filtered.len(), 1);
     assert!(r.filtered.get("var").is_none());
-    assert_eq!(*r.filtered.get("run").unwrap(), 2);
+    // TODO: change filter_tar to properly make this run/somefile, but eh...we're
+    // just going to accept this stuff in the future but ignore it anyways.
+    assert_eq!(*r.filtered.get("somefile").unwrap(), 1);
 
     Ok(())
 }


### PR DESCRIPTION
tar: Don't filter out toplevel /run, /proc etc

Otherwise we break things when using this code to process
a "non-ostree" image.

Signed-off-by: Colin Walters <walters@verbum.org>

---

store: Accept just containers.bootc for as bootable

This allows us to accept images to that don't have any metadata
keys starting with `ostree`.

---