### PR TITLE
tar/write: Ensure repofd outlives child spawn

### DIFF
--- a/lib/src/tar/write.rs
+++ b/lib/src/tar/write.rs
@@ -417,6 +417,8 @@ pub async fn write_tar(
     let mut c = tokio::process::Command::from(c);
     c.kill_on_drop(true);
     let mut r = c.spawn()?;
+    // Ensure the fd is open until the process is spawned
+    drop(repofd);
     tracing::trace!("Spawned ostree child process");
     // Safety: We passed piped() for all of these
     let child_stdin = r.stdin.take().unwrap();


### PR DESCRIPTION
Might help with https://github.com/ostreedev/ostree-rs-ext/issues/664 But I didn't manage to reliably reproduce this.