### PR TITLE
installdeps: drop dnf config-manager

### DIFF
--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -15,9 +15,6 @@ enabled=1
 enabled_metadata=1
 EOF
 
-# Pull skopeo and ostree from updates-testing, since we depend on new features in our git main
-dnf config-manager --set-enabled updates-testing
-
 # Our tests depend on this
 dnf -y install skopeo
 


### PR DESCRIPTION
Because dnf5 broke it and keeping both working is annoying and we didn't really need it.